### PR TITLE
Add delta Diff algorithm support pr2 

### DIFF
--- a/git/src/internal/pack/encode.rs
+++ b/git/src/internal/pack/encode.rs
@@ -1,11 +1,18 @@
+use entity::git;
 use sha1::{Digest, Sha1};
 use std::io::{Cursor, Write};
 use std::sync::Arc;
 
+use crate::internal::diff::DeltaDiff;
 use crate::internal::object::ObjectT;
 use crate::internal::zlib::stream::deflate::Write as Writer;
 
 use std::io::Error;
+
+use super::header::EntryHeader;
+
+const SLID_WINDWOS:usize = 20;
+
 #[allow(unused)]
 struct Encoder<W> {
     inner: W,
@@ -24,8 +31,44 @@ where
         Self { inner, hash }
     }
     pub fn add_objects(&mut self, obj_vec: Vec<Arc<dyn ObjectT>>) -> Result<(), Error> {
+        let ls = obj_vec.len();
         for obj in obj_vec {
             let obj_data = encode_one_object(obj)?;
+            self.hash.update(&obj_data);
+            self.inner.write_all(&obj_data)?;
+        }
+        Ok(())
+    }
+    /// Added batch insertion support for offset delta compression. 
+    /// Note: The input array should meet the requirements of magic sorting, otherwise a good delta compression rate cannot be obtained
+    pub fn add_oject_model(&mut self,obj_vec: Vec<git::Model>) -> Result<(), Error> {
+        let batch_size = obj_vec.len() ;
+        for i in 0..batch_size{
+            let mut best_j = SLID_WINDWOS+1;
+            let mut best_ssam_rate: f64 = 0.0;
+            // delta from base object by slid window
+            for j in 1..SLID_WINDWOS{
+                if i < j  {
+                    break;
+                }
+                let pos = i-j;
+                if !obj_vec[pos].object_type.eq(&obj_vec[i].object_type)  {
+                    break;
+                }
+                let differ= DeltaDiff::new(&obj_vec[i-j].data, &obj_vec[i].data);
+                let diff_rate = differ.get_ssam_rate();
+                if (diff_rate > best_ssam_rate) && diff_rate > 0.5 {
+                    best_ssam_rate = diff_rate;
+                    best_j = j;
+                }
+            }  
+            let obj_data = if best_j==SLID_WINDWOS+1{
+                encode_one_ojbect(EntryHeader::from_string(&obj_vec[i].object_type).to_number() , obj_vec[i].data.len(), &obj_vec[i].data)
+            }else {
+                let differ= DeltaDiff::new(&obj_vec[i-best_j].data, &obj_vec[i].data);
+                let after = differ.encode();
+                encode_one_ojbect(6 , after.len(), &after)
+            }.unwrap();
             self.hash.update(&obj_data);
             self.inner.write_all(&obj_data)?;
         }
@@ -100,6 +143,37 @@ fn encode_one_object(obj: Arc<dyn ObjectT>) -> Result<Vec<u8>, Error> {
     out.flush().expect("zlib flush should never fail");
     header_data.append(&mut out.into_inner());
     Ok(header_data)
+}
+
+fn encode_one_ojbect(git_type: u8, size :usize, data: &[u8])-> Result<Vec<u8>, Error>{
+    let mut out = Writer::new(Vec::new());
+    let mut header_data = vec![(0x80 | (git_type << 4)) + (size & 0x0f) as u8];
+    let mut _size = size >> 4;
+    if _size > 0 {
+        while _size > 0 {
+            if _size >> 7 > 0 {
+                header_data.push((0x80 | _size) as u8);
+                _size >>= 7;
+            } else {
+                header_data.push((_size) as u8);
+                break;
+            }
+        }
+    } else {
+        header_data.push(0);
+    }
+    if let Err(err) = std::io::copy(&mut Cursor::new(data), &mut out) {
+        match err.kind() {
+            std::io::ErrorKind::Other => return Err(err),
+            err => {
+                unreachable!("Should never see other errors than zlib, but got {:?}", err,)
+            }
+        }
+    };
+    out.flush().expect("zlib flush should never fail");
+    header_data.append(&mut out.into_inner());
+    Ok(header_data)
+
 }
 
 fn u32_vec(value: u32) -> Vec<u8> {

--- a/git/src/internal/pack/header.rs
+++ b/git/src/internal/pack/header.rs
@@ -50,4 +50,16 @@ impl EntryHeader {
             _ => panic!("can put compute the delta hash value"),
         }
     }
+    pub fn to_number(&self) -> u8{
+        match self {
+            EntryHeader::Commit => 1,
+            EntryHeader::Tree => 2,
+            EntryHeader::Blob => 3,
+            EntryHeader::Tag => 4,
+            EntryHeader::RefDelta { base_id:_ } => 7,
+            EntryHeader::OfsDelta { base_distance:_ } => 6,
+            
+            
+        }
+    }
 }


### PR DESCRIPTION
see the func : git::internal::pack::encode::Encoder::add_oject_model
```rust
    /// Added batch insertion support for offset delta compression. 
    /// Note: The input array should meet the requirements of magic sorting, otherwise a good delta compression rate cannot be obtained
```