### PR TITLE
Clean the bazel build warning message

### DIFF
--- a/git/src/internal/diff/mod.rs
+++ b/git/src/internal/diff/mod.rs
@@ -1,7 +1,16 @@
+//!
+//!
+//!
+//!
+//!
+//! 
+#[cfg(feature="diff_mydrs")]
 use diffs::myers;
 use diffs::Diff;
+
 const DATA_INS_LEN: usize = 0x7f;
 const VAR_INT_ENCODING_BITS: u8 = 7;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Optype {
     Data,
@@ -23,7 +32,6 @@ pub struct DeltaDiff<'a> {
     ssam_r: f64,
 }
 
-
 impl <'a>DeltaDiff<'a> {
     /// Diff the two u8 array slice , Type should be same.
     /// Return the DeltaDiff struct.
@@ -35,6 +43,7 @@ impl <'a>DeltaDiff<'a> {
             ssam: 0,
             ssam_r: 0.00,
         };
+
         #[cfg(feature="diff_mydrs")]
         myers::diff(
             &mut delta_diff,

--- a/git/src/lib.rs
+++ b/git/src/lib.rs
@@ -10,5 +10,6 @@ pub mod lfs;
 pub mod protocol;
 pub mod structure;
 pub mod utils;
+
 #[cfg(test)]
 mod tests {}


### PR DESCRIPTION
When building the project with Bazel, I got the `warning` message:

```bash
warning: unused import: diffs::myers
--> git/src/internal/diff/mod.rs:1:5
|
1 | use diffs::myers;
| ^^^^^^^^^^^^
|
= note: #[warn(unused_imports)] on by default
```

So, I added the `cfg` for `use` to remove it.

```Rust
#[cfg(feature="diff_mydrs")]
use diffs::Myers;
```