### PR TITLE
Add empty workspace for cargo build command

### DIFF
--- a/craft/Cargo.toml
+++ b/craft/Cargo.toml
@@ -3,10 +3,8 @@ name = "git-craft"
 version = "0.1.0"
 edition = "2021"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-# [workspace]
+[workspace]
+members = []
 
 [dependencies]
 anyhow = "1.0.75"


### PR DESCRIPTION
Fix build `craft` problem:

```bash
this may be fixable by adding `craft` to the `workspace.members` array of the manifest located at: x:\xxx\mega\Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```