### PR TITLE
add `Pack::decode_async` & limit Memory in one `Pack` (not Global)

### DIFF
--- a/ceres/src/protocol/pack.rs
+++ b/ceres/src/protocol/pack.rs
@@ -6,7 +6,6 @@
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::thread::{self};
 
 use anyhow::Result;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -354,11 +353,15 @@ impl PackProtocol {
 
     async fn unpack_and_persist(&self, mr: &MergeRequest, repo: &Repo, pack_file: Bytes) -> bool {
         let (sender, receiver) = mpsc::channel();
-        thread::spawn(|| {
-            let tmp = PathBuf::from("/tmp/.cache_temp");
-            let mut p = Pack::new(None, Some(1024 * 1024 * 1024 * 4), Some(tmp.clone()));
-            p.decode(&mut Cursor::new(pack_file), Some(sender)).unwrap();
-        });
+        // thread::spawn(|| {
+        //     let tmp = PathBuf::from("/tmp/.cache_temp");
+        //     let mut p = Pack::new(None, Some(1024 * 1024 * 1024 * 4), Some(tmp.clone()));
+        //     p.decode(&mut Cursor::new(pack_file), Some(sender)).unwrap();
+        // });
+        let tmp = PathBuf::from("/tmp/.cache_temp");
+        let p = Pack::new(None, Some(1024 * 1024 * 1024 * 4), Some(tmp.clone()));
+        p.decode_async(Cursor::new(pack_file), sender); //Pack moved here
+
         let storage = self.context.services.mega_storage.clone();
         let mut entry_list = Vec::new();
 

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -213,7 +213,6 @@ impl _Cache for Caches {
 #[cfg(test)]
 mod test {
     use std::env;
-    use std::sync::atomic::AtomicUsize;
 
     use super::*;
     use venus::hash::SHA1;
@@ -225,13 +224,13 @@ mod test {
         let a = CacheObject {
             data_decompress: vec![0; 1024],
             hash: SHA1::new(&String::from("a").into_bytes()),
-            mem_recorder: Arc::new(AtomicUsize::default()),
+            mem_recorder: None,
             ..Default::default()
         };
         let b = CacheObject {
             data_decompress: vec![0; 1636],
             hash: SHA1::new(&String::from("b").into_bytes()),
-            mem_recorder: Arc::new(AtomicUsize::default()),
+            mem_recorder: None,
             ..Default::default()
         };
         // insert a
@@ -254,7 +253,7 @@ mod test {
         let c = CacheObject {
             data_decompress: vec![0; 2049],
             hash: SHA1::new(&String::from("c").into_bytes()),
-            mem_recorder: Arc::new(AtomicUsize::default()),
+            mem_recorder: None,
             ..Default::default()
         };
         cache.insert(c.offset, c.hash, c.clone());

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -213,6 +213,7 @@ impl _Cache for Caches {
 #[cfg(test)]
 mod test {
     use std::env;
+    use std::sync::atomic::AtomicUsize;
 
     use super::*;
     use venus::hash::SHA1;
@@ -224,11 +225,13 @@ mod test {
         let a = CacheObject {
             data_decompress: vec![0; 1024],
             hash: SHA1::new(&String::from("a").into_bytes()),
+            mem_recorder: Arc::new(AtomicUsize::default()),
             ..Default::default()
         };
         let b = CacheObject {
             data_decompress: vec![0; 1636],
             hash: SHA1::new(&String::from("b").into_bytes()),
+            mem_recorder: Arc::new(AtomicUsize::default()),
             ..Default::default()
         };
         // insert a
@@ -251,6 +254,7 @@ mod test {
         let c = CacheObject {
             data_decompress: vec![0; 2049],
             hash: SHA1::new(&String::from("c").into_bytes()),
+            mem_recorder: Arc::new(AtomicUsize::default()),
             ..Default::default()
         };
         cache.insert(c.offset, c.hash, c.clone());

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -295,7 +295,6 @@ mod test {
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
             mem_recorder: None,
-            ..Default::default()
         };
         assert!(a.heap_size() == 1024);
 
@@ -314,7 +313,6 @@ mod test {
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
             mem_recorder: None,
-            ..Default::default()
         };
         println!("a.heap_size() = {}", a.heap_size());
 
@@ -326,7 +324,6 @@ mod test {
             offset: 0,
             hash: SHA1::new(&vec![1; 20]),
             mem_recorder: None,
-            ..Default::default()
         };
         {
             let r = cache.insert(
@@ -431,7 +428,6 @@ mod test {
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
             mem_recorder: None,
-            ..Default::default()
         };
         let s = bincode::serialize(&a).unwrap();
         let b: CacheObject = bincode::deserialize(&s).unwrap();

--- a/mercury/src/internal/pack/encode.rs
+++ b/mercury/src/internal/pack/encode.rs
@@ -176,6 +176,6 @@ mod tests {
             Some(PathBuf::from("/tmp/.cache_temp")),
         );
         let mut reader = Cursor::new(writter);
-        p.decode(&mut reader, None).expect("pack file format error");
+        p.decode(&mut reader, |_|{}).expect("pack file format error");
     }
 }

--- a/mercury/src/internal/pack/mod.rs
+++ b/mercury/src/internal/pack/mod.rs
@@ -13,6 +13,7 @@ pub mod cache_object;
 use venus::hash::SHA1;
 use threadpool::ThreadPool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 use venus::internal::object::ObjectTrait;
 use crate::internal::pack::waitlist::Waitlist;
 
@@ -30,6 +31,7 @@ pub struct Pack {
     pub waitlist: Arc<Waitlist>,
     pub caches: Arc<Caches>,
     pub mem_limit: usize,
+    pub cache_objs_mem: Arc<AtomicUsize> // the memory size of CacheObjects in this Pack
 }
 
 #[cfg(test)]


### PR DESCRIPTION
1. `Pack::decode_async`: run decode in another thread and send Entry by `Sender`
2. limit Memory in one `Pack` (not Global)
3. fix double drop in `CacheObject` clone