### PR TITLE
only use `mimalloc` on Windows & add arg to control remove_tmp in `Pack::new`

### DIFF
--- a/ceres/src/pack/handler.rs
+++ b/ceres/src/pack/handler.rs
@@ -125,6 +125,7 @@ pub fn decode_for_receiver(pack_file: Bytes) -> Result<Receiver<Entry>, GitError
         None,
         Some(1024 * 1024 * 1024 * cache_size),
         Some(tmp.clone()),
+        true
     );
     p.decode_async(Cursor::new(pack_file), sender); //Pack moved here
     Ok(receiver)

--- a/mercury/Cargo.toml
+++ b/mercury/Cargo.toml
@@ -26,6 +26,7 @@ tokio.workspace = true
 lru-mem = "0.3.0"
 bincode = "1.3.3"
 uuid = { version = "1.7.0", features = ["v4"]}
-mimalloc = "0.1.39" # avoid sticking on dropping
-rayon =  "1.9.0"
 byteorder = "1.5.0"
+
+[target.'cfg(windows)'.dependencies] # only on Windows
+mimalloc = "0.1.39" # avoid sticking on dropping on Windows

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -201,7 +201,9 @@ impl _Cache for Caches {
             self.pool.join();
             self.lru_cache.lock().unwrap().clear();
             self.hash_set.clear();
+            self.hash_set.shrink_to_fit();
             self.map_offset.clear();
+            self.map_offset.shrink_to_fit();
         });
 
         time_it!("Remove tmp dir", {

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -114,6 +114,13 @@ impl Caches {
         self.map_offset.capacity() * (std::mem::size_of::<usize>() + std::mem::size_of::<SHA1>())
         + self.hash_set.capacity() * (std::mem::size_of::<SHA1>())
     }
+
+    /// remove the tmp dir
+    pub fn remove_tmp_dir(&self) {
+        time_it!("Remove tmp dir", {
+            fs::remove_dir_all(&self.tmp_path).unwrap(); //very slow
+        });
+    }
 }
 
 impl _Cache for Caches {
@@ -204,10 +211,6 @@ impl _Cache for Caches {
             self.hash_set.shrink_to_fit();
             self.map_offset.clear();
             self.map_offset.shrink_to_fit();
-        });
-
-        time_it!("Remove tmp dir", {
-            fs::remove_dir_all(&self.tmp_path).unwrap(); //very slow
         });
 
         assert_eq!(self.pool.queued_count(), 0);

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -340,7 +340,7 @@ impl Pack {
         println!("The pack file has {} objects", self.number);
 
         let mut offset: usize = 12;
-        let i = Arc::new(AtomicUsize::new(1));
+        let i = Arc::new(AtomicUsize::new(0));
         
         // debug log thread g   
         #[cfg(debug_assertions)]
@@ -369,7 +369,7 @@ impl Pack {
             });
         } // LOG
 
-        while i.load(Ordering::Relaxed) <= self.number {
+        while i.load(Ordering::Relaxed) < self.number {
             // 3 parts: Waitlist + TheadPool + Caches
             // hardcode the limit of the tasks of threads_pool queue, to limit memory
             while self.memory_used() > self.mem_limit || self.pool.queued_count() > 2000 {

--- a/mercury/src/internal/pack/encode.rs
+++ b/mercury/src/internal/pack/encode.rs
@@ -227,6 +227,7 @@ mod tests {
                 None,
                 Some(1024 * 20),
                 Some(PathBuf::from("/tmp/.cache_temp")),
+                true
             );
             let mut reader = Cursor::new(data);
             p.decode(&mut reader, |_|{}).expect("pack file format error");

--- a/mercury/src/internal/pack/mod.rs
+++ b/mercury/src/internal/pack/mod.rs
@@ -31,7 +31,8 @@ pub struct Pack {
     pub waitlist: Arc<Waitlist>,
     pub caches: Arc<Caches>,
     pub mem_limit: usize,
-    pub cache_objs_mem: Arc<AtomicUsize> // the memory size of CacheObjects in this Pack
+    pub cache_objs_mem: Arc<AtomicUsize>, // the memory size of CacheObjects in this Pack
+    pub clean_tmp: bool,
 }
 
 #[cfg(test)]

--- a/mercury/src/lib.rs
+++ b/mercury/src/lib.rs
@@ -3,9 +3,12 @@
 //!
 //!
 
-// to avoid sticking on Dropping large HashMap
+// to avoid sticking on Dropping large HashMap on Windows
+// but, mimalloc won't release memory to OS after dropping (TODO)
 // see [issue](https://github.com/rust-lang/rust/issues/121747)
+#[cfg(target_os = "windows")]
 use mimalloc::MiMalloc;
+#[cfg(target_os = "windows")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
1. only use `mimalloc` on Windows //`mimalloc` won't release memory to OS after dropping
2. add arg `clean_tmp` to `Pack::new`
3. fix log: `cnt` & `Caches_mem`. // shrink_to_fit()