### PR TITLE
Update development.md and a bugfix in loading ssh keys

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -75,45 +75,52 @@
 5. Config environment variables for local test. For local testing, Mega uses the .env file to configure the required parameters. However, before starting the project, you also need to configure the environment variables such as `DB_USERNAME`, `DB_PASSWORD`, and `DB_HOST`.
 
    ```ini
-   ## Fillin the following environment variables with values you set
-   DB = "postgres" # {postgres, mysql}
-   DB_USERNAME = "mega"
-   DB_PASSWORD = "mega"
-   DB_HOST = "localhost"
+    # Fillin the following environment variables with values you set
 
-   MEGA_DB_POSTGRESQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
-   MEGA_DB_MYSQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
-   MEGA_DB_MAX_CONNECTIONS = 32
-   MEGA_DB_MIN_CONNECTIONS = 16
+    ## Database Configuration
+    DB = "postgres" # {postgres, mysql}
+    DB_USERNAME = "mega"
+    DB_PASSWORD = "mega"
+    DB_HOST = "localhost"
 
-   ## Whether to disabling SQLx Log
-   MEGA_DB_SQLX_LOGGING = false
+    MEGA_DB_POSTGRESQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
+    MEGA_DB_MYSQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
+    MEGA_DB_MAX_CONNECTIONS = 32
+    MEGA_DB_MIN_CONNECTIONS = 16
 
-   ## Mega SSH key path
-   MEGA_SSH_KEY = "/tmp/.mega/ssh"
+    MEGA_DB_SQLX_LOGGING = false # Whether to disabling SQLx Log
+    ## End Database Configuration
 
-   ## file storage configuration
-   MEGA_RAW_STORAGE = "LOCAL" # LOCAL or REMOTE
 
-   ## This configuration is used to set the local path of the project storage
-   MEGA_OBJ_LOCAL_PATH = "/tmp/.mega/objects"
+    ## SSH/HTTPS Key Configruation
+    MEGA_SSH_KEY = "/tmp/.mega/ssh"
+    MEGA_HTTPS_PUBLIC_KEY = ""
+    MEGA_HTTPS_PRIVATE_KEY = ""
+    ## End SSH/HTTPS Key Configruation
 
-   ## Remote cloud storage region
-   MEGA_OBS_ACCESS_KEY = ""
-   MEGA_OBS_SECRET_KEY = ""
-   MEGA_OBJ_REMOTE_REGION = ""
-   MEGA_OBJ_REMOTE_ENDPOINT = ""
+    ## File Storage Configuration
+    MEGA_RAW_STORAGE = "LOCAL" # LOCAL or REMOTE
 
-   ## Unit KB. If the object file size exceeds the threshold value, it will be handled by file storage instead of the database
-   MEGA_BIG_OBJ_THRESHOLD_SIZE = 1024
+    ### This configuration is used to set the local path of the project storage
+    MEGA_OBJ_LOCAL_PATH = "/tmp/.mega/objects"
+    MEGA_LFS_OBJ_LOCAL_PATH = "/tmp/.mega/lfs"
 
-   ## Init directory configuration
-   ## Only import directory support multi-branch commit and tag, repo under regular directory only support main branch only
-   MEGA_IMPORT_DIRS = "/third-part"
+    ### This configuration is used to set the object storage service like S3
+    MEGA_OBS_ACCESS_KEY = ""
+    MEGA_OBS_SECRET_KEY = ""
+    MEGA_OBJ_REMOTE_REGION = "cn-east-3" # Remote cloud storage region
+    MEGA_OBJ_REMOTE_ENDPOINT = "https://obs.cn-east-3.myhuaweicloud.com" # Override the endpoint URL used for remote storage services
 
-   ## Decode cache configuration
-   MEGA_PACK_DECODE_MEM_SIZE = 4 # Unit GB.
-   MEGA_PACK_DECODE_CACHE_PATH = "/tmp/.mega/cache"
+    ## If the object file size exceeds the threshold value, it will be handled by file storage instead of the database
+    MEGA_BIG_OBJ_THRESHOLD_SIZE = 1024 # Unit KB.
+
+    ## Only import directory support multi-branch commit and tag, repo under regular directory only support main branch only
+    MEGA_IMPORT_DIRS = "/third-part"
+
+    ## Decode cache configuration
+    MEGA_PACK_DECODE_MEM_SIZE = 4 # Unit GB.
+    MEGA_PACK_DECODE_CACHE_PATH = "/tmp/.mega/cache"
+    CLEAN_CACHE_AFTER_DECODE = true
 
    ```
 
@@ -218,45 +225,53 @@
 5. Config `.env`.
 
    ```ini
-   ## Fillin the following environment variables with values you set
-   DB = "postgres" # {postgres, mysql}
-   DB_USERNAME = "mega"
-   DB_PASSWORD = "mega"
-   DB_HOST = "localhost"
+    # Fillin the following environment variables with values you set
 
-   MEGA_DB_POSTGRESQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
-   MEGA_DB_MYSQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
-   MEGA_DB_MAX_CONNECTIONS = 32
-   MEGA_DB_MIN_CONNECTIONS = 16
+    ## Database Configuration
+    DB = "postgres" # {postgres, mysql}
+    DB_USERNAME = "mega"
+    DB_PASSWORD = "mega"
+    DB_HOST = "localhost"
 
-   ## Whether to disabling SQLx Log
-   MEGA_DB_SQLX_LOGGING = false
+    MEGA_DB_POSTGRESQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
+    MEGA_DB_MYSQL_URL = "${DB}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}/mega"
+    MEGA_DB_MAX_CONNECTIONS = 32
+    MEGA_DB_MIN_CONNECTIONS = 16
 
-   ## Mega SSH key path
-   MEGA_SSH_KEY = "/tmp/.mega/ssh"
+    MEGA_DB_SQLX_LOGGING = false # Whether to disabling SQLx Log
+    ## End Database Configuration
 
-   ## file storage configuration
-   MEGA_RAW_STORAGE = "LOCAL" # LOCAL or REMOTE
 
-   ## This configuration is used to set the local path of the project storage
-   MEGA_OBJ_LOCAL_PATH = "/tmp/.mega/objects"
+    ## SSH/HTTPS Key Configruation
+    MEGA_SSH_KEY = "/tmp/.mega/ssh"
+    MEGA_HTTPS_PUBLIC_KEY = ""
+    MEGA_HTTPS_PRIVATE_KEY = ""
+    ## End SSH/HTTPS Key Configruation
 
-   ## Remote cloud storage region
-   MEGA_OBS_ACCESS_KEY = ""
-   MEGA_OBS_SECRET_KEY = ""
-   MEGA_OBJ_REMOTE_REGION = ""
-   MEGA_OBJ_REMOTE_ENDPOINT = ""
+    ## File Storage Configuration
+    MEGA_RAW_STORAGE = "LOCAL" # LOCAL or REMOTE
 
-   ## Unit KB. If the object file size exceeds the threshold value, it will be handled by file storage instead of the database
-   MEGA_BIG_OBJ_THRESHOLD_SIZE = 1024
+    ### This configuration is used to set the local path of the project storage
+    MEGA_OBJ_LOCAL_PATH = "/tmp/.mega/objects"
+    MEGA_LFS_OBJ_LOCAL_PATH = "/tmp/.mega/lfs"
 
-   ## Init directory configuration
-   ## Only import directory support multi-branch commit and tag, repo under regular directory only support main branch only
-   MEGA_IMPORT_DIRS = "/third-part"
+    ### This configuration is used to set the object storage service like S3
+    MEGA_OBS_ACCESS_KEY = ""
+    MEGA_OBS_SECRET_KEY = ""
+    MEGA_OBJ_REMOTE_REGION = "cn-east-3" # Remote cloud storage region
+    MEGA_OBJ_REMOTE_ENDPOINT = "https://obs.cn-east-3.myhuaweicloud.com" # Override the endpoint URL used for remote storage services
 
-   ## Decode cache configuration
-   MEGA_PACK_DECODE_MEM_SIZE = 4 # Unit GB.
-   MEGA_PACK_DECODE_CACHE_PATH = "/tmp/.mega/cache"
+    ## If the object file size exceeds the threshold value, it will be handled by file storage instead of the database
+    MEGA_BIG_OBJ_THRESHOLD_SIZE = 1024 # Unit KB.
+
+    ## Only import directory support multi-branch commit and tag, repo under regular directory only support main branch only
+    MEGA_IMPORT_DIRS = "/third-part"
+
+    ## Decode cache configuration
+    MEGA_PACK_DECODE_MEM_SIZE = 4 # Unit GB.
+    MEGA_PACK_DECODE_CACHE_PATH = "/tmp/.mega/cache"
+    CLEAN_CACHE_AFTER_DECODE = true
+
    ```
 
 6. Init Mega.

--- a/gateway/src/ssh_server.rs
+++ b/gateway/src/ssh_server.rs
@@ -3,10 +3,10 @@
 //!
 use std::collections::HashMap;
 use std::env;
-use std::fs::File;
+use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -103,6 +103,12 @@ pub async fn start_server(command: &SshOptions) {
 pub fn load_key() -> Result<KeyPair> {
     let key_root = env::var("MEGA_SSH_KEY").expect("MEGA_SSH_KEY is not set in .env file");
     let key_path = PathBuf::from(&key_root).join("id_rsa");
+
+    if !Path::new(&key_root).exists() {
+        // create ssh directory if not exists
+        create_dir_all(&key_root).unwrap();
+    }
+
     if !key_path.exists() {
         // generate a keypair if not exists
         let keys = KeyPair::generate_ed25519().unwrap();


### PR DESCRIPTION
As described in #369.

The default value of MEGA_SSH_KEY in .env is /tmp/.mega/ssh, and it will be deleted every time after reboot.
So I think it would be better to check and recreate a directory rather than ask user to do it manually  in doc.  

Any suggestions and ideas are welcomed!