### PR TITLE
add blank line before `commit msg` & optimize `log`

### DIFF
--- a/libra/src/command/commit.rs
+++ b/libra/src/command/commit.rs
@@ -13,7 +13,7 @@ use mercury::internal::object::commit::Commit;
 use mercury::internal::object::tree::{Tree, TreeItem, TreeItemMode};
 use mercury::internal::object::ObjectTrait;
 
-use super::save_object;
+use super::{format_commit_msg, save_object};
 
 #[derive(Parser, Debug)]
 pub struct CommitArgs {
@@ -38,7 +38,8 @@ pub async fn execute(args: CommitArgs) {
 
     /* Create & save commit objects */
     let parents_commit_ids = get_parents_ids().await;
-    let commit = Commit::from_tree_id(tree.id, parents_commit_ids, args.message.as_str());
+    // There must be a `blank line`(\n) before `message`, or remote unpack failed
+    let commit = Commit::from_tree_id(tree.id, parents_commit_ids, &format_commit_msg(&args.message, None));
 
     // TODO  default signature created in `from_tree_id`, wait `git config` to set correct user info
 

--- a/libra/src/command/log.rs
+++ b/libra/src/command/log.rs
@@ -15,6 +15,8 @@ use std::collections::VecDeque;
 use std::str::FromStr;
 use mercury::hash::SHA1;
 use mercury::internal::object::commit::Commit;
+
+use super::parse_commit_msg;
 #[derive(Parser, Debug)]
 pub struct LogArgs {
     /// Limit the number of output
@@ -103,7 +105,8 @@ pub async fn execute(args: LogArgs) {
             message
         };
         message.push_str(&format!("\nAuthor: {}", commit.author));
-        message.push_str(&format!("\n{}\n", commit.message));
+        let (msg, _) = parse_commit_msg(&commit.message);
+        message.push_str(&format!("\n{}\n", msg));
 
         #[cfg(unix)]
         {

--- a/libra/src/command/mod.rs
+++ b/libra/src/command/mod.rs
@@ -81,19 +81,24 @@ pub fn format_commit_msg(msg: &str, gpg_sig: Option<&str>) -> String {
 }
 /// parse commit message
 pub fn parse_commit_msg(msg_gpg: &str) -> (String, Option<String>) {
-    let parse_pos = msg_gpg.find("\n\n").unwrap_or(msg_gpg.len());
-    if parse_pos < msg_gpg.len() {
-        let gpg_sig = msg_gpg[..parse_pos].trim().to_string();
-        // TODO: support ssh signature
-        if gpg_sig.starts_with("gpgsig -----BEGIN PGP SIGNATURE-----")
-            && gpg_sig.ends_with("-----END PGP SIGNATURE-----")
-        {
-            (msg_gpg[parse_pos + 2..].to_string(), Some(gpg_sig))
-        } else {
+    let parse_pos = msg_gpg.find("\n\n");
+    match parse_pos {
+        // if parse_pos < msg_gpg.len() {
+        Some(parse_pos) => {
+            let gpg_sig = msg_gpg[..parse_pos].trim().to_string();
+            // TODO: support ssh signature
+            if gpg_sig.starts_with("gpgsig -----BEGIN PGP SIGNATURE-----")
+                && gpg_sig.ends_with("-----END PGP SIGNATURE-----")
+            {
+                (msg_gpg[parse_pos + 2..].to_string(), Some(gpg_sig))
+            } else {
+                (msg_gpg[1..].to_string(), None)
+            }
+        }
+        None => {
+            assert!(msg_gpg.starts_with('\n'), "commit message format error");
             (msg_gpg[1..].to_string(), None)
         }
-    } else {
-        (msg_gpg[1..].to_string(), None)
     }
 }
 

--- a/libra/src/command/mod.rs
+++ b/libra/src/command/mod.rs
@@ -65,6 +65,21 @@ pub fn ask_basic_auth() -> BasicAuth {
     BasicAuth { username, password }
 }
 
+/// Format commit message with GPG signature<br>
+/// There must be a `blank line`(\n) before `message`, or remote unpack failed.<br>
+/// If there is `GPG signature`,
+/// `blank line` should be placed between `signature` and `message`
+pub fn format_commit_msg(msg: &str, gpg_sig: Option<&str>) -> String {
+    match gpg_sig {
+        None => {
+            format!("\n{}", msg)
+        }
+        Some(gpg) => {
+            format!("{}\n\n{}", gpg, msg)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use mercury::internal::object::commit::Commit;


### PR DESCRIPTION
- fix: add `\n` before `message` in `Command/commit` not `object/commit
- optimize log (remove GPG display)