### PR TITLE
fix: specify param `config` type in definition

### DIFF
--- a/mega/src/cli.rs
+++ b/mega/src/cli.rs
@@ -96,6 +96,7 @@ fn cli() -> Command {
             Arg::new("config")
                 .short('c')
                 .long("config")
+                .value_parser(clap::value_parser!(PathBuf))
                 .help("Sets a config file work directory"),
         )
 }

--- a/mega/src/lib.rs
+++ b/mega/src/lib.rs
@@ -7,7 +7,8 @@ mod tests {
 
     #[test]
     fn test_cli() {
-        let args = "service http".split(' ').collect();
+        let config_path = "config.toml";
+        let args = vec!["-c", config_path, "service", "multi", "http"];
         cli::parse(Some(args)).expect("Failed to start http service");
     }
 }


### PR DESCRIPTION
- from default `String` to `PathBuf`