### PR TITLE
fix verify fake ca fail

### DIFF
--- a/neptune/mega/tunnel/punch.js
+++ b/neptune/mega/tunnel/punch.js
@@ -237,17 +237,9 @@ export default function ({ app, mesh }) {
       var key = new crypto.PrivateKey({ type: 'rsa', bits: 2048 })
       var pKey = new crypto.PublicKey(key)
       var cert = new crypto.Certificate({
-        subject: { CN: 'Fake CA' },
-        publicKey: pKey,
-        privateKey: key,
-        days: 365,
-      })
-
-      cert = new crypto.Certificate({
         subject: { CN: role },
         publicKey: pKey,
         privateKey: key,
-        issuer: cert,
         days: 365,
       })
 


### PR DESCRIPTION
fix for 3e8304afdf0774329edc5853b15953000623b36c, which could cause tls handshake error under some circumstances.