### PR TITLE
Add GitHub Webhook Support in `gateway`

### DIFF
--- a/aries/src/service/relay_server.rs
+++ b/aries/src/service/relay_server.rs
@@ -226,7 +226,8 @@ pub async fn repo_list(
 async fn github_webhook(
     Path(peer_id): Path<String>,
     Json(payload): Json<Value>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<String, (StatusCode, String)> {
+    tracing::info!("GitHub Webhook Event: {:?} \n {:?}", peer_id, payload);
     unimplemented!();
 }
 

--- a/aries/src/service/relay_server.rs
+++ b/aries/src/service/relay_server.rs
@@ -2,13 +2,14 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use callisto::{ztm_node, ztm_repo_info};
 use clap::Parser;
+use serde_json::Value;
 use common::config::Config;
 use gemini::ztm::hub::{LocalHub, ZTMUserPermit, ZTMCA};
 use gemini::{Node, RelayGetParams, RelayResultRes, RepoInfo};
@@ -104,7 +105,8 @@ pub fn routers() -> Router<AppState> {
         .route("/ping", get(ping))
         .route("/node_list", get(node_list))
         .route("/repo_provide", post(repo_provide))
-        .route("/repo_list", get(repo_list));
+        .route("/repo_list", get(repo_list))
+        .route("/github/webhook/:peer_id", post(github_webhook));
 
     Router::new().merge(router)
 }
@@ -218,6 +220,14 @@ pub async fn repo_list(
         repo_info_list_result.push(repo.clone());
     }
     Ok(Json(repo_info_list_result))
+}
+
+/// Forwards the GitHub webhook to the corresponding peer.
+async fn github_webhook(
+    Path(peer_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    unimplemented!();
 }
 
 async fn loop_running(context: Context) {

--- a/gateway/src/api/api_router.rs
+++ b/gateway/src/api/api_router.rs
@@ -15,7 +15,7 @@ use ceres::model::{
 };
 use common::model::CommonResult;
 
-use crate::api::mr_router;
+use crate::api::{github_router, mr_router};
 use crate::api::ApiServiceState;
 
 use super::ztm_router;
@@ -34,6 +34,7 @@ pub fn routers() -> Router<ApiServiceState> {
         .merge(router)
         .merge(mr_router::routers())
         .merge(ztm_router::routers())
+        .merge(github_router::routers())
 }
 
 async fn get_blob_object(

--- a/gateway/src/api/github_router.rs
+++ b/gateway/src/api/github_router.rs
@@ -1,18 +1,11 @@
-use std::fmt::format;
 use axum::{Json, Router};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use axum::routing::{get, post};
+use axum::routing::post;
 use lazy_static::lazy_static;
 use reqwest::Client;
-use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde_json::Value;
-use common::model::CommonResult;
 use crate::api::ApiServiceState;
-
-// const GITHUB_API_SERVER: &str = "https://api.github.com";
-// const OWNER: &str = "web3infra-foundation";
-// const REPO: &str = "mega";
 
 lazy_static! {
     static ref CLIENT: Client = Client::builder()
@@ -51,6 +44,12 @@ async fn webhook(
             let _title = payload["pull_request"]["title"].as_str().unwrap();
             let _body = payload["pull_request"]["body"].as_str().unwrap();
         }
+    } else if event_type == "issues" {
+        let action = payload["action"].as_str().unwrap();
+        tracing::debug!("Issue action: {}", action);
+        let title = payload["issue"]["title"].as_str().unwrap();
+        let body = payload["issue"]["body"].as_str().unwrap();
+        tracing::debug!("Issue: {} - {}", title, body);
     }
 
     Ok("WebHook OK")

--- a/gateway/src/api/github_router.rs
+++ b/gateway/src/api/github_router.rs
@@ -1,0 +1,71 @@
+use std::fmt::format;
+use axum::{Json, Router};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use lazy_static::lazy_static;
+use reqwest::Client;
+use reqwest::header::{ACCEPT, AUTHORIZATION};
+use serde_json::Value;
+use common::model::CommonResult;
+use crate::api::ApiServiceState;
+
+// const GITHUB_API_SERVER: &str = "https://api.github.com";
+// const OWNER: &str = "web3infra-foundation";
+// const REPO: &str = "mega";
+
+lazy_static! {
+    static ref CLIENT: Client = Client::builder()
+        .user_agent("Mega/0.0.1") // IMPORTANT, or 403 Forbidden
+        .build()
+        .unwrap();
+}
+
+pub fn routers() -> Router<ApiServiceState> {
+    Router::new()
+        .route("/github/webhook", post(webhook))
+}
+
+async fn webhook(
+    headers: HeaderMap,
+    Json(payload): Json<Value>
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let event_type = headers
+        .get("X-GitHub-Event")
+        .and_then(|v| v.to_str().ok())
+        .expect("Missing X-GitHub-Event header");
+
+    tracing::debug!("WebHook Event Type: {}", event_type);
+
+    if event_type == "pull_request" {
+        let action = payload["action"].as_str().unwrap();
+        tracing::debug!("PR action: {}", action);
+
+        if ["opened", "reopened", "synchronize"].contains(&action) {
+            let url = payload["pull_request"]["url"].as_str().unwrap();
+            let files = get_pr_files(url).await;
+            let commits = get_pr_commits(url).await;
+            tracing::debug!("PR: {:#?}", files);
+            tracing::debug!("Commits: {:#?}", commits);
+        } else if action == "edited" { // PR title or body edited
+            let _title = payload["pull_request"]["title"].as_str().unwrap();
+            let _body = payload["pull_request"]["body"].as_str().unwrap();
+        }
+    }
+
+    Ok("WebHook OK")
+}
+
+async fn get_pr_files(pr_url: &str) -> Value {
+    get_request(&format!("{}/files", pr_url)).await
+}
+
+async fn get_pr_commits(pr_url: &str) -> Value {
+    get_request(&format!("{}/commits", pr_url)).await
+}
+
+/// Send a GET request to the given URL and return the JSON response.
+async fn get_request(url: &str) -> Value {
+    let resp = CLIENT.get(url).send().await.unwrap();
+    resp.json().await.unwrap()
+}

--- a/gateway/src/api/mod.rs
+++ b/gateway/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod api_router;
 pub mod mr_router;
 pub mod oauth;
 pub mod ztm_router;
+mod github_router;
 
 #[derive(Clone)]
 pub struct ApiServiceState {

--- a/taurus/src/event/github_webhook.rs
+++ b/taurus/src/event/github_webhook.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use crate::event::{EventBase, EventType};
+use crate::queue::get_mq;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubWebhookEvent {
+    pub _type: WebhookType,
+    pub payload: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum WebhookType {
+    PullRequest,
+    Issue,
+}
+
+impl std::fmt::Display for GithubWebhookEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GitHub Webhook Event: {:?}", self._type)
+    }
+}
+
+#[async_trait]
+impl EventBase for GithubWebhookEvent {
+    async fn process(&self) {
+        tracing::info!("Handling GitHub Webhook Event: [{}]", &self);
+    }
+}
+
+impl GithubWebhookEvent {
+    // Create and enqueue this event.
+    pub fn notify(_type: WebhookType, payload: Value) {
+        get_mq().send(EventType::GithubWebhook(GithubWebhookEvent {
+            _type,
+            payload,
+        }));
+    }
+}
+
+// For storing the data into database.
+impl From<GithubWebhookEvent> for Value {
+    fn from(value: GithubWebhookEvent) -> Self {
+        serde_json::to_value(value).unwrap()
+    }
+}
+
+impl TryFrom<Value> for GithubWebhookEvent {
+    type Error = crate::event::Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        let res: GithubWebhookEvent = serde_json::from_value(value)?;
+        Ok(res)
+    }
+}

--- a/taurus/src/event/github_webhook.rs
+++ b/taurus/src/event/github_webhook.rs
@@ -13,7 +13,18 @@ pub struct GithubWebhookEvent {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum WebhookType {
     PullRequest,
-    Issue,
+    Issues,
+    Unknown(String),
+}
+
+impl From<&str> for WebhookType {
+    fn from(value: &str) -> Self {
+        match value {
+            "pull_request" => WebhookType::PullRequest,
+            "issues" => WebhookType::Issues,
+            _ => WebhookType::Unknown(value.to_string()),
+        }
+    }
 }
 
 impl std::fmt::Display for GithubWebhookEvent {
@@ -25,7 +36,8 @@ impl std::fmt::Display for GithubWebhookEvent {
 #[async_trait]
 impl EventBase for GithubWebhookEvent {
     async fn process(&self) {
-        tracing::info!("Handling GitHub Webhook Event: [{}]", &self);
+        tracing::info!("Processing: [{}]", &self);
+        tracing::info!("Payload: {:#?}", &self.payload);
     }
 }
 

--- a/taurus/src/event/mod.rs
+++ b/taurus/src/event/mod.rs
@@ -7,13 +7,16 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
+use github_webhook::GithubWebhookEvent;
 
 pub mod api_request;
+mod github_webhook;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EventType {
     ApiRequest(ApiRequestEvent),
+    GithubWebhook(GithubWebhookEvent),
 
     // Reserved
     ErrorEvent,
@@ -53,6 +56,8 @@ impl EventType {
             // so you have to manually add a process logic for your event here.
             EventType::ApiRequest(evt) => evt.process().await,
             // EventType::SomeOtherEvent(xxx) => xxx.process().await,
+
+            EventType::GithubWebhook(evt) => evt.process().await,
 
             // This won't happen unless failed to load events from database.
             // And that's because of a event conversion error.

--- a/taurus/src/event/mod.rs
+++ b/taurus/src/event/mod.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use github_webhook::GithubWebhookEvent;
 
 pub mod api_request;
-mod github_webhook;
+pub mod github_webhook;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
- add webhook router in `gateway` & `aries`
- support PR & issue event
- use `GithubWebhookEvent` to notify webhook
- for PR event, fetch details (files & commits) and add to payload
- TODO: forward webhook from `aries` to local mega