### PR TITLE
refact: Removed the `Hash` struct `to_plain_str` function.

### DIFF
--- a/ceres/src/api_service/import_api_service.rs
+++ b/ceres/src/api_service/import_api_service.rs
@@ -160,7 +160,7 @@ impl ApiHandler for ImportApiService {
         p_stack.push_back(start_commit);
 
         while let Some(commit) = p_stack.pop_front() {
-            let root_tree = self.get_tree_by_hash(&commit.tree_id.to_plain_str()).await;
+            let root_tree = self.get_tree_by_hash(&commit.tree_id.to_string()).await;
             let reachable = self
                 .reachable_in_tree(&root_tree, path, target)
                 .await
@@ -169,7 +169,7 @@ impl ApiHandler for ImportApiService {
                 let mut p_ids = vec![];
                 for p_id in commit.parent_commit_ids.clone() {
                     if !visited.contains(&p_id) {
-                        p_ids.push(p_id.to_plain_str());
+                        p_ids.push(p_id.to_string());
                         visited.insert(p_id);
                     }
                 }

--- a/ceres/src/api_service/mod.rs
+++ b/ceres/src/api_service/mod.rs
@@ -84,7 +84,7 @@ pub trait ApiHandler: Send + Sync {
         let parent = file_path.parent().unwrap();
         if let Some(tree) = self.search_tree_by_path(parent).await? {
             if let Some(item) = tree.tree_items.into_iter().find(|x| x.name == filename) {
-                match self.get_raw_blob_by_hash(&item.id.to_plain_str()).await {
+                match self.get_raw_blob_by_hash(&item.id.to_string()).await {
                     Ok(Some(model)) => {
                         return Ok(Some(String::from_utf8(model.data.unwrap()).unwrap()))
                     }
@@ -103,7 +103,7 @@ pub trait ApiHandler: Send + Sync {
                 "can't find target parent tree under latest commit".to_string(),
             ));
         };
-        let commit = self.get_tree_relate_commit(&tree.id.to_plain_str()).await;
+        let commit = self.get_tree_relate_commit(&tree.id.to_string()).await;
         self.convert_commit_to_info(commit)
     }
 
@@ -135,7 +135,7 @@ pub trait ApiHandler: Send + Sync {
                     tree.tree_items
                         .iter()
                         .filter(|x| x.mode == TreeItemMode::Tree)
-                        .map(|x| x.id.to_plain_str())
+                        .map(|x| x.id.to_string())
                         .collect(),
                 )
                 .await;
@@ -145,7 +145,7 @@ pub trait ApiHandler: Send + Sync {
                     tree.tree_items
                         .iter()
                         .filter(|x| x.mode == TreeItemMode::Blob)
-                        .map(|x| x.id.to_plain_str())
+                        .map(|x| x.id.to_string())
                         .collect(),
                 )
                 .await;
@@ -158,13 +158,13 @@ pub trait ApiHandler: Send + Sync {
                     .unwrap();
                 let commit_map: HashMap<String, Commit> = commits
                     .into_iter()
-                    .map(|x| (x.id.to_plain_str(), x))
+                    .map(|x| (x.id.to_string(), x))
                     .collect();
 
                 let root_commit: Option<Commit> = None;
                 for item in tree.tree_items {
                     let mut info: TreeCommitItem = item.clone().into();
-                    if let Some(commit_id) = item_to_commit.get(&item.id.to_plain_str()) {
+                    if let Some(commit_id) = item_to_commit.get(&item.id.to_string()) {
                         let commit = if let Some(commit) = commit_map.get(commit_id) {
                             commit
                         } else {
@@ -178,7 +178,7 @@ pub trait ApiHandler: Send + Sync {
                                 .traverse_commit_history(&path, root_commit, &item)
                                 .await
                         };
-                        info.oid = commit.id.to_plain_str();
+                        info.oid = commit.id.to_string();
                         info.message = commit.format_message();
                         info.date = commit.committer.timestamp.to_string();
                     }
@@ -208,7 +208,7 @@ pub trait ApiHandler: Send + Sync {
         };
 
         let res = LatestCommitInfo {
-            oid: commit.id.to_plain_str(),
+            oid: commit.id.to_string(),
             date: commit.committer.timestamp.to_string(),
             short_message: message,
             author,
@@ -249,7 +249,7 @@ pub trait ApiHandler: Send + Sync {
                     .find(|x| x.name == target_name);
 
                 if let Some(search_res) = search_res {
-                    let res = self.get_tree_by_hash(&search_res.id.to_plain_str()).await;
+                    let res = self.get_tree_by_hash(&search_res.id.to_string()).await;
                     search_tree = res.clone();
                     update_tree.push(res);
                 } else {
@@ -289,7 +289,7 @@ pub trait ApiHandler: Send + Sync {
                     .iter()
                     .find(|x| x.name == target_name);
                 if let Some(search_res) = search_res {
-                    let res = self.get_tree_by_hash(&search_res.id.to_plain_str()).await;
+                    let res = self.get_tree_by_hash(&search_res.id.to_string()).await;
                     search_tree = res.clone();
                 } else {
                     return Ok(None);
@@ -333,7 +333,7 @@ pub trait ApiHandler: Send + Sync {
                 .iter()
                 .find(|x| x.name == target_name)
             {
-                search_tree = self.get_tree_by_hash(&search_res.id.to_plain_str()).await;
+                search_tree = self.get_tree_by_hash(&search_res.id.to_string()).await;
                 update_item_tree.push_back((search_tree.clone(), component));
             } else {
                 stack.push_back(component);
@@ -408,7 +408,7 @@ pub trait ApiHandler: Send + Sync {
                     .iter()
                     .find(|x| x.name == target_name);
                 if let Some(search_res) = search_res {
-                    search_tree = self.get_tree_by_hash(&search_res.id.to_plain_str()).await;
+                    search_tree = self.get_tree_by_hash(&search_res.id.to_string()).await;
                 } else {
                     return Ok(false);
                 }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -227,7 +227,7 @@ impl MonoApiService {
                 tree_comparation.left_tree.pop_front()
             {
                 let new_tree: Tree = storage
-                    .get_tree_by_hash(&new_tree.to_plain_str())
+                    .get_tree_by_hash(&new_tree.to_string())
                     .await
                     .unwrap()
                     .unwrap()
@@ -235,7 +235,7 @@ impl MonoApiService {
 
                 let base_tree = if let Some(base_tree) = base_tree {
                     let base_tree: Tree = storage
-                        .get_tree_by_hash(&base_tree.to_plain_str())
+                        .get_tree_by_hash(&base_tree.to_string())
                         .await
                         .unwrap()
                         .unwrap()
@@ -332,10 +332,10 @@ impl MonoApiService {
                         vec![SHA1::from_str(&p_ref.ref_commit_hash).unwrap()],
                         &commit.message,
                     );
-                    p_commit_id = p_commit.id.to_plain_str();
+                    p_commit_id = p_commit.id.to_string();
                     // update p_ref
-                    p_ref.ref_commit_hash = p_commit.id.to_plain_str();
-                    p_ref.ref_tree_hash = target_hash.to_plain_str();
+                    p_ref.ref_commit_hash = p_commit.id.to_string();
+                    p_ref.ref_tree_hash = target_hash.to_string();
                     storage.update_ref(p_ref).await.unwrap();
                     storage.save_mega_commits(vec![p_commit]).await.unwrap();
                 } else {
@@ -450,7 +450,7 @@ impl TreeComparation {
     //     let diff: Vec<_> = new_set.symmetric_difference(&base_set).cloned().collect();
     //     for item in diff {
     //         if item.mode == TreeItemMode::Tree {
-    //             let t_id = item.id.to_plain_str();
+    //             let t_id = item.id.to_string();
     //             if !self.left_tree.contains(&t_id) {
     //                 self.left_tree.push_back(t_id);
     //             }

--- a/ceres/src/pack/import_repo.rs
+++ b/ceres/src/pack/import_repo.rs
@@ -188,7 +188,7 @@ impl PackHandler for ImportRepo {
         // traverse commit's all parents to find the commit that client does not have
         while let Some(temp) = traversal_list.pop() {
             for p_commit_id in temp.parent_commit_ids {
-                let p_commit_id = p_commit_id.to_plain_str();
+                let p_commit_id = p_commit_id.to_string();
 
                 if !have.contains(&p_commit_id) && !want_clone.contains(&p_commit_id) {
                     let parent: Commit = storage
@@ -206,7 +206,7 @@ impl PackHandler for ImportRepo {
 
         let want_tree_ids = want_commits
             .iter()
-            .map(|c| c.tree_id.to_plain_str())
+            .map(|c| c.tree_id.to_string())
             .collect();
         let want_trees: HashMap<SHA1, Tree> = storage
             .get_trees_by_hashes(self.repo.repo_id, want_tree_ids)
@@ -371,7 +371,7 @@ impl ImportRepo {
             .into_iter()
             .map(|tree| {
                 let mut model: mega_tree::Model = tree.into();
-                model.commit_id = new_commit.id.to_plain_str();
+                model.commit_id = new_commit.id.to_string();
                 model.into()
             })
             .collect();
@@ -380,8 +380,8 @@ impl ImportRepo {
             .await
             .unwrap();
 
-        root_ref.ref_commit_hash = new_commit.id.to_plain_str();
-        root_ref.ref_tree_hash = new_commit.tree_id.to_plain_str();
+        root_ref.ref_commit_hash = new_commit.id.to_string();
+        root_ref.ref_tree_hash = new_commit.tree_id.to_string();
         storage.update_ref(root_ref).await.unwrap();
         storage.save_mega_commits(vec![new_commit]).await.unwrap();
         Ok(())

--- a/ceres/src/pack/mod.rs
+++ b/ceres/src/pack/mod.rs
@@ -126,7 +126,7 @@ pub trait PackHandler: Send + Sync {
         let mut search_tree_ids = vec![];
         let mut search_blob_ids = vec![];
         for item in &tree.tree_items {
-            let hash = item.id.to_plain_str();
+            let hash = item.id.to_string();
             if !exist_objs.contains(&hash) && counted_obj.insert(hash.clone()) {
                 if item.mode == TreeItemMode::Tree {
                     search_tree_ids.push(hash.clone())
@@ -172,7 +172,7 @@ pub trait PackHandler: Send + Sync {
         let mut search_blob_ids = vec![];
 
         for item in &tree.tree_items {
-            let hash = item.id.to_plain_str();
+            let hash = item.id.to_string();
             if exist_objs.insert(hash.clone()) {
                 if item.mode == TreeItemMode::Tree {
                     search_tree_ids.push(hash);

--- a/ceres/src/pack/monorepo.rs
+++ b/ceres/src/pack/monorepo.rs
@@ -83,7 +83,7 @@ impl PackHandler for MonoRepo {
                         .map(|x| x.id);
                     if let Some(sha1) = sha1 {
                         tree = storage
-                            .get_trees_by_hashes(vec![sha1.to_plain_str()])
+                            .get_trees_by_hashes(vec![sha1.to_string()])
                             .await
                             .unwrap()[0]
                             .clone()
@@ -105,8 +105,8 @@ impl PackHandler for MonoRepo {
                 .save_ref(
                     self.path.to_str().unwrap(),
                     None,
-                    &c.id.to_plain_str(),
-                    &c.tree_id.to_plain_str(),
+                    &c.id.to_string(),
+                    &c.tree_id.to_string(),
                 )
                 .await
                 .unwrap();
@@ -114,7 +114,7 @@ impl PackHandler for MonoRepo {
 
             vec![Refs {
                 ref_name: MEGA_BRANCH_NAME.to_string(),
-                ref_hash: c.id.to_plain_str(),
+                ref_hash: c.id.to_string(),
                 default_branch: true,
                 ..Default::default()
             }]
@@ -131,7 +131,7 @@ impl PackHandler for MonoRepo {
         for entry in receiver {
             if current_commit.is_none() {
                 if entry.obj_type == ObjectType::Commit {
-                    current_commit_id = entry.hash.to_plain_str();
+                    current_commit_id = entry.hash.to_string();
                     let commit = Commit::from_bytes(&entry.data, entry.hash).unwrap();
                     current_commit = Some(commit);
                 }
@@ -259,7 +259,7 @@ impl PackHandler for MonoRepo {
         // traverse commit's all parents to find the commit that client does not have
         while let Some(temp) = traversal_list.pop() {
             for p_commit_id in temp.parent_commit_ids {
-                let p_commit_id = p_commit_id.to_plain_str();
+                let p_commit_id = p_commit_id.to_string();
 
                 if !have.contains(&p_commit_id) && !want_clone.contains(&p_commit_id) {
                     let parent: Commit = storage
@@ -277,7 +277,7 @@ impl PackHandler for MonoRepo {
 
         let want_tree_ids = want_commits
             .iter()
-            .map(|c| c.tree_id.to_plain_str())
+            .map(|c| c.tree_id.to_string())
             .collect();
         let want_trees: HashMap<SHA1, Tree> = storage
             .get_trees_by_hashes(want_tree_ids)
@@ -393,7 +393,7 @@ impl PackHandler for MonoRepo {
         let storage = self.context.services.mono_storage.clone();
         if let Some(mut mr_ref) = storage.get_mr_ref(&ref_name).await.unwrap() {
             mr_ref.ref_commit_hash = refs.new_id.clone();
-            mr_ref.ref_tree_hash = commit.unwrap().tree_id.to_plain_str();
+            mr_ref.ref_tree_hash = commit.unwrap().tree_id.to_string();
             storage.update_ref(mr_ref).await.unwrap();
         } else {
             storage
@@ -401,7 +401,7 @@ impl PackHandler for MonoRepo {
                     self.path.to_str().unwrap(),
                     Some(ref_name),
                     &refs.new_id,
-                    &commit.unwrap().tree_id.to_plain_str(),
+                    &commit.unwrap().tree_id.to_string(),
                 )
                 .await
                 .unwrap();

--- a/jupiter/src/utils/converter.rs
+++ b/jupiter/src/utils/converter.rs
@@ -69,7 +69,7 @@ impl MegaModelConverter {
     fn traverse_from_root(&self) {
         let root_tree = &self.root_tree;
         let mut mega_tree: mega_tree::Model = root_tree.to_owned().into();
-        mega_tree.commit_id = self.commit.id.to_plain_str();
+        mega_tree.commit_id = self.commit.id.to_string();
         self.mega_trees
             .borrow_mut()
             .insert(root_tree.id, mega_tree.clone().into());
@@ -81,7 +81,7 @@ impl MegaModelConverter {
             if item.mode == TreeItemMode::Tree {
                 let child_tree = self.tree_maps.get(&item.id).unwrap();
                 let mut mega_tree: mega_tree::Model = child_tree.to_owned().into();
-                mega_tree.commit_id = self.commit.id.to_plain_str();
+                mega_tree.commit_id = self.commit.id.to_string();
                 self.mega_trees
                     .borrow_mut()
                     .insert(child_tree.id, mega_tree.clone().into());
@@ -89,7 +89,7 @@ impl MegaModelConverter {
             } else {
                 let blob = self.blob_maps.get(&item.id).unwrap();
                 let mut mega_blob: mega_blob::Model = blob.into();
-                mega_blob.commit_id = self.commit.id.to_plain_str();
+                mega_blob.commit_id = self.commit.id.to_string();
                 self.mega_blobs
                     .borrow_mut()
                     .insert(blob.id, mega_blob.clone().into());
@@ -107,8 +107,8 @@ impl MegaModelConverter {
             id: generate_id(),
             path: "/".to_owned(),
             ref_name: MEGA_BRANCH_NAME.to_owned(),
-            ref_commit_hash: commit.id.to_plain_str(),
-            ref_tree_hash: commit.tree_id.to_plain_str(),
+            ref_commit_hash: commit.id.to_string(),
+            ref_tree_hash: commit.tree_id.to_string(),
             created_at: chrono::Utc::now().naive_utc(),
             updated_at: chrono::Utc::now().naive_utc(),
         };

--- a/libra/src/command/branch.rs
+++ b/libra/src/command/branch.rs
@@ -112,7 +112,7 @@ pub async fn create_branch(new_branch: String, branch_or_commit: Option<String>)
         .unwrap_or_else(|_| panic!("fatal: not a valid object name: '{}'", commit_id));
 
     // create branch
-    Branch::update_branch(&new_branch, &commit_id.to_plain_str(), None).await;
+    Branch::update_branch(&new_branch, &commit_id.to_string(), None).await;
 }
 
 async fn delete_branch(branch_name: String) {
@@ -138,7 +138,7 @@ async fn show_current_branch() {
     let head = Head::current().await;
     match head {
         Head::Detached(commit_hash) => {
-            println!("HEAD detached at {}", &commit_hash.to_plain_str()[..8]);
+            println!("HEAD detached at {}", &commit_hash.to_string()[..8]);
         }
         Head::Branch(name) => {
             println!("{}", name);
@@ -163,7 +163,7 @@ async fn list_branches(remotes: bool) {
 
     let head = Head::current().await;
     if let Head::Detached(commit) = head {
-        let s = "HEAD detached at  ".to_string() + &commit.to_plain_str()[..8];
+        let s = "HEAD detached at  ".to_string() + &commit.to_string()[..8];
         let s = s.green();
         println!("{}", s);
     };
@@ -252,7 +252,7 @@ mod tests {
             let first_branch_name = "first_branch".to_string();
             let args = BranchArgs {
                 new_branch: Some(first_branch_name.clone()),
-                commit_hash: Some(first_commit_id.to_plain_str()),
+                commit_hash: Some(first_commit_id.to_string()),
                 list: false,
                 delete: None,
                 set_upstream_to: None,
@@ -324,7 +324,7 @@ mod tests {
         };
         commit::execute(args).await;
         let hash = Head::current_commit().await.unwrap();
-        Branch::update_branch("master", &hash.to_plain_str(), Some("origin")).await; // create remote branch
+        Branch::update_branch("master", &hash.to_string(), Some("origin")).await; // create remote branch
         assert!(get_target_commit("origin/master").await.is_ok());
 
         let args = BranchArgs {

--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -96,7 +96,7 @@ async fn setup(remote_repo: String) {
                 .await
                 .expect("origin HEAD branch not found");
 
-            Branch::update_branch(&name, &origin_head_branch.commit.to_plain_str(), None).await;
+            Branch::update_branch(&name, &origin_head_branch.commit.to_string(), None).await;
             Head::update(Head::Branch(name.to_owned()), None).await;
 
             // set config: remote.origin.url

--- a/libra/src/command/commit.rs
+++ b/libra/src/command/commit.rs
@@ -61,7 +61,7 @@ pub async fn execute(args: CommitArgs) {
         .unwrap();
 
     /* update HEAD */
-    update_head(&commit.id.to_plain_str()).await;
+    update_head(&commit.id.to_string()).await;
 }
 
 /// recursively create tree from index's tracked entries

--- a/libra/src/command/diff.rs
+++ b/libra/src/command/diff.rs
@@ -217,10 +217,10 @@ pub async fn diff(
         }
 
         let old_index = old_hash.map_or("0000000".to_string(), |h| {
-            h.to_plain_str()[0..8].to_string()
+            h.to_string()[0..8].to_string()
         });
         let new_index = new_hash.map_or("0000000".to_string(), |h| {
-            h.to_plain_str()[0..8].to_string()
+            h.to_string()[0..8].to_string()
         });
         writeln!(w, "index {}..{}", old_index, new_index).unwrap();
 

--- a/libra/src/command/fetch.rs
+++ b/libra/src/command/fetch.rs
@@ -182,7 +182,7 @@ pub async fn fetch_repository(remote_config: &RemoteConfig, branch: Option<Strin
 
         let checksum = SHA1::from_bytes(&pack_data[pack_data.len() - 20..]);
         assert_eq!(hash, checksum);
-        let checksum = checksum.to_plain_str();
+        let checksum = checksum.to_string();
         println!("checksum: {}", checksum);
 
         if pack_data.len() > 32 { // 12 header + 20 hash
@@ -253,10 +253,10 @@ async fn current_have() -> Vec<String> {
         |commit: &Commit,
          inserted: &mut HashSet<String>,
          c_pending: &mut std::collections::BinaryHeap<QueueItem>| {
-            if inserted.contains(&commit.id.to_plain_str()) {
+            if inserted.contains(&commit.id.to_string()) {
                 return;
             }
-            inserted.insert(commit.id.to_plain_str());
+            inserted.insert(commit.id.to_string());
             c_pending.push(QueueItem {
                 priority: commit.committer.timestamp,
                 commit: commit.id,
@@ -279,7 +279,7 @@ async fn current_have() -> Vec<String> {
     let mut have = Vec::new();
     while have.len() < 32 && !c_pending.is_empty() {
         let item = c_pending.pop().unwrap();
-        have.push(item.commit.to_plain_str());
+        have.push(item.commit.to_string());
 
         let commit: Commit = load_object(&item.commit).unwrap();
         for parent in commit.parent_commit_ids {

--- a/libra/src/command/log.rs
+++ b/libra/src/command/log.rs
@@ -44,7 +44,7 @@ pub async fn get_reachable_commits(commit_hash: String) -> Vec<Commit> {
 
         let parent_commit_ids = commit.parent_commit_ids.clone();
         for parent_commit_id in parent_commit_ids {
-            queue.push_back(parent_commit_id.to_plain_str());
+            queue.push_back(parent_commit_id.to_string());
         }
         reachable_commits.push(commit);
     }
@@ -73,7 +73,7 @@ pub async fn execute(args: LogArgs) {
         }
     }
 
-    let commit_hash = Head::current_commit().await.unwrap().to_plain_str();
+    let commit_hash = Head::current_commit().await.unwrap().to_string();
 
     let mut reachable_commits = get_reachable_commits(commit_hash.clone()).await;
     // default sort with signature time
@@ -90,7 +90,7 @@ pub async fn execute(args: LogArgs) {
             let mut message = format!(
                 "{} {}",
                 "commit".yellow(),
-                &commit.id.to_plain_str().yellow()
+                &commit.id.to_string().yellow()
             );
 
             // TODO other branch's head should shown branch name
@@ -209,8 +209,8 @@ mod tests {
             _ => panic!("should be branch"),
         };
 
-        Branch::update_branch(&branch_name, &commit_6.id.to_plain_str(), None).await;
+        Branch::update_branch(&branch_name, &commit_6.id.to_string(), None).await;
 
-        commit_6.id.to_plain_str()
+        commit_6.id.to_string()
     }
 }

--- a/libra/src/command/merge.rs
+++ b/libra/src/command/merge.rs
@@ -42,8 +42,8 @@ pub async fn execute(args: MergeArgs) {
     } else if lca.id == current_commit.id {
         println!(
             "Updating {}..{}",
-            &current_commit.id.to_plain_str()[..6],
-            &target_commit.id.to_plain_str()[..6]
+            &current_commit.id.to_string()[..6],
+            &target_commit.id.to_string()[..6]
         );
         // fast-forward merge
         merge_ff(target_commit).await;
@@ -54,8 +54,8 @@ pub async fn execute(args: MergeArgs) {
 }
 
 async fn lca_commit(lhs: &Commit, rhs: &Commit) -> Option<Commit> {
-    let lhs_reachable = log::get_reachable_commits(lhs.id.to_plain_str()).await;
-    let rhs_reachable = log::get_reachable_commits(rhs.id.to_plain_str()).await;
+    let lhs_reachable = log::get_reachable_commits(lhs.id.to_string()).await;
+    let rhs_reachable = log::get_reachable_commits(rhs.id.to_string()).await;
 
     // Commit `eq` is based on tree_id, so we shouldn't use it here
 
@@ -88,7 +88,7 @@ async fn merge_ff(commit: Commit) {
     let head = Head::current().await;
     match head {
         Head::Branch(branch_name) => {
-            Branch::update_branch(&branch_name, &commit.id.to_plain_str(), None).await;
+            Branch::update_branch(&branch_name, &commit.id.to_string(), None).await;
         }
         Head::Detached(_) => {
             Head::update(Head::Detached(commit.id), None).await;

--- a/libra/src/command/push.rs
+++ b/libra/src/command/push.rs
@@ -67,7 +67,7 @@ pub async fn execute(args: PushArgs) {
     let repo_url = Config::get_remote_url(&repository).await;
 
     let branch = args.refspec.unwrap_or(branch);
-    let commit_hash = Branch::find_branch(&branch, None).await.unwrap().commit.to_plain_str();
+    let commit_hash = Branch::find_branch(&branch, None).await.unwrap().commit.to_string();
 
     println!("pushing {}({}) to {}({})", branch, commit_hash, repository, repo_url);
 
@@ -87,7 +87,7 @@ pub async fn execute(args: PushArgs) {
 
     let tracked_ref = refs.iter().find(|r| r._ref == tracked_branch);
     // [0; 20] if new branch
-    let remote_hash = tracked_ref.map(|r| r._hash.clone()).unwrap_or(SHA1::default().to_plain_str());
+    let remote_hash = tracked_ref.map(|r| r._hash.clone()).unwrap_or(SHA1::default().to_string());
     if remote_hash == commit_hash {
         println!("Everything up-to-date");
         return;

--- a/libra/src/command/switch.rs
+++ b/libra/src/command/switch.rs
@@ -91,7 +91,7 @@ async fn restore_to_commit(commit_id: SHA1) {
     let restore_args = RestoreArgs {
         worktree: true,
         staged: true,
-        source: Some(commit_id.to_plain_str()),
+        source: Some(commit_id.to_string()),
         pathspec: vec![util::working_dir_string()],
     };
     restore::execute(restore_args).await;
@@ -113,7 +113,7 @@ mod tests {
             "--worktree",
             "--staged",
             "--source",
-            &commit_id.to_plain_str(),
+            &commit_id.to_string(),
             util::working_dir().to_str().unwrap(),
         ]);
         println!("{:?}", restore_args);

--- a/libra/src/internal/branch.rs
+++ b/libra/src/internal/branch.rs
@@ -144,7 +144,7 @@ mod tests {
     async fn test_search_branch() {
         test::setup_with_new_libra().await;
 
-        let commit_hash = SHA1::default().to_plain_str();
+        let commit_hash = SHA1::default().to_string();
         Branch::update_branch("upstream/origin/master", &commit_hash, None).await; // should match
         Branch::update_branch("origin/master", &commit_hash, Some("upstream")).await; // should match
         Branch::update_branch("master", &commit_hash, Some("upstream/origin")).await; // should match

--- a/libra/src/internal/head.rs
+++ b/libra/src/internal/head.rs
@@ -93,7 +93,7 @@ impl Head {
                 }
                 match new_head {
                     Head::Detached(commit_hash) => {
-                        head.commit = Set(Some(commit_hash.to_plain_str()));
+                        head.commit = Set(Some(commit_hash.to_string()));
                         head.name = Set(None);
                     }
                     Head::Branch(branch_name) => {
@@ -114,7 +114,7 @@ impl Head {
                 }
                 match new_head {
                     Head::Detached(commit_hash) => {
-                        head.commit = Set(Some(commit_hash.to_plain_str()));
+                        head.commit = Set(Some(commit_hash.to_string()));
                     }
                     Head::Branch(branch_name) => {
                         head.name = Set(Some(branch_name));

--- a/libra/src/internal/protocol/https_client.rs
+++ b/libra/src/internal/protocol/https_client.rs
@@ -162,7 +162,7 @@ impl HttpsClient {
             let (hash, mut refs) = pkt_line.split_at(40); // hex SHA1 string is 40 bytes
             refs = refs.trim();
             if !read_first_line {
-                if hash == SHA1::default().to_plain_str() {
+                if hash == SHA1::default().to_string() {
                     break; // empty repo, return empty list // TODO: parse capability
                 }
                 let (head, caps) = refs.split_once('\0').unwrap();

--- a/libra/src/utils/client_storage.rs
+++ b/libra/src/utils/client_storage.rs
@@ -39,7 +39,7 @@ impl ClientStorage {
 
     /// e.g. 6ae8a755... -> 6a/e8a755...
     fn transform_path(&self, hash: &SHA1) -> String {
-        let hash = hash.to_plain_str();
+        let hash = hash.to_string();
         Path::new(&hash[0..2])
             .join(&hash[2..hash.len()])
             .into_os_string()
@@ -61,7 +61,7 @@ impl ClientStorage {
         } else {
             self.get_from_pack(obj_id)?
                 .map(|x| x.1)
-                .ok_or(GitError::ObjectNotFound(obj_id.to_plain_str()))
+                .ok_or(GitError::ObjectNotFound(obj_id.to_string()))
         }
     }
 
@@ -79,7 +79,7 @@ impl ClientStorage {
         objs.extend(self.list_objects_loose());
 
         objs.into_iter()
-            .filter(|x| x.to_plain_str().starts_with(obj_id))
+            .filter(|x| x.to_string().starts_with(obj_id))
             .collect()
     }
 
@@ -170,7 +170,7 @@ impl ClientStorage {
             // Ok(self.get_from_pack(object_id)?.unwrap().0)
             self.get_from_pack(object_id)?
                 .map(|x| x.0)
-                .ok_or(GitError::ObjectNotFound(object_id.to_plain_str()))
+                .ok_or(GitError::ObjectNotFound(object_id.to_string()))
         }
     }
 

--- a/mercury/src/hash.rs
+++ b/mercury/src/hash.rs
@@ -36,12 +36,12 @@ pub struct SHA1(pub [u8; 20]);
 impl Display for SHA1 {
     /// # Attention
     /// cause of the color chars for ,if you want to use the string without color ,
-    /// please call the func:`to_plain_str()` rather than the func:`to_string()`
+    /// please call the func:`to_string()` rather than the func:`to_string()`
     /// # Example
     ///  the hash value `18fd2deaaf152c7f1222c52fb2673f6192b375f0`<br>
     ///  will be the `1;31m8d2deaaf152c7f1222c52fb2673f6192b375f00m`
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.to_plain_str().red().bold())
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 impl AsRef<[u8]> for SHA1{
@@ -89,7 +89,7 @@ impl std::str::FromStr for SHA1 {
 ///
 /// 3. `to` Prefix:
 ///    Methods with the `to` prefix are used for outputting the `SHA1` value in various formats. This prefix indicates a transformation or
-///    conversion of the `SHA1` instance into another representation. For example, `pub fn to_plain_str(self) -> String` converts the SHA1
+///    conversion of the `SHA1` instance into another representation. For example, `pub fn to_string(self) -> String` converts the SHA1
 ///    value to a plain hexadecimal string, and `pub fn to_data(self) -> Vec<u8>` converts it into a byte vector. The `to` prefix
 ///    thus serves as a clear indicator that the method is exporting or transforming the SHA1 value into a different format.
 ///
@@ -126,9 +126,9 @@ impl SHA1 {
         h
     }
 
-    /// Export sha1 value to plain String without the color chars
-    pub fn to_plain_str(self) -> String {
-        hex::encode(self.0)
+    /// Export sha1 value to String with the color 
+    pub fn to_color_str(self) -> String {
+        self.to_string().red().bold().to_string()
     }
 
     /// Export sha1 value to a byte array
@@ -139,6 +139,7 @@ impl SHA1 {
 
 #[cfg(test)]
 mod tests {
+    
     use std::io::BufReader;
     use std::io::Read;
     use std::io::Seek;
@@ -159,7 +160,7 @@ mod tests {
         // Known SHA1 hash for "Hello, world!"
         let expected_sha1_hash = "943a702d06f34599aee1f8da8ef9f7296031d699";
 
-        assert_eq!(sha1.to_plain_str(), expected_sha1_hash);
+        assert_eq!(sha1.to_string(), expected_sha1_hash);
     }
 
     #[test]
@@ -175,7 +176,7 @@ mod tests {
         buffered.read_exact(&mut buffer).unwrap();
         let signature = SHA1::from_bytes(buffer.as_ref());
         assert_eq!(
-            signature.to_plain_str(),
+            signature.to_string(),
             "1d0e6c14760c956c173ede71cb28f33d921e232f"
         );
     }
@@ -188,7 +189,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            sha1.to_plain_str(),
+            sha1.to_string(),
             "8ab686eafeb1f44702738c8b0f24f2567c36da6d"
         );
     }
@@ -200,7 +201,7 @@ mod tests {
         match SHA1::from_str(hash_str) {
             Ok(hash) => {
                 assert_eq!(
-                    hash.to_plain_str(),
+                    hash.to_string(),
                     "8ab686eafeb1f44702738c8b0f24f2567c36da6d"
                 );
             }
@@ -209,13 +210,13 @@ mod tests {
     }
 
     #[test]
-    fn test_sha1_to_plain_str() {
+    fn test_sha1_to_string() {
         let hash_str = "8ab686eafeb1f44702738c8b0f24f2567c36da6d";
 
         match SHA1::from_str(hash_str) {
             Ok(hash) => {
                 assert_eq!(
-                    hash.to_plain_str(),
+                    hash.to_string(),
                     "8ab686eafeb1f44702738c8b0f24f2567c36da6d"
                 );
             }
@@ -226,7 +227,7 @@ mod tests {
     #[test]
     fn test_sha1_to_data() {
         let hash_str = "8ab686eafeb1f44702738c8b0f24f2567c36da6d";
-
+        
         match SHA1::from_str(hash_str) {
             Ok(hash) => {
                 assert_eq!(

--- a/mercury/src/internal/model/blob.rs
+++ b/mercury/src/internal/model/blob.rs
@@ -9,7 +9,7 @@ impl From<&Blob> for mega_blob::Model {
     fn from(value: &Blob) -> Self {
         mega_blob::Model {
             id: generate_id(),
-            blob_id: value.id.to_plain_str(),
+            blob_id: value.id.to_string(),
             size: 0,
             commit_id: String::new(),
             name: String::new(),
@@ -23,7 +23,7 @@ impl From<&Blob> for git_blob::Model {
         git_blob::Model {
             id: generate_id(),
             repo_id: 0,
-            blob_id: value.id.to_plain_str(),
+            blob_id: value.id.to_string(),
             size: 0,
             commit_id: String::new(),
             name: None,
@@ -36,7 +36,7 @@ impl From<Blob> for raw_blob::Model {
     fn from(value: Blob) -> Self {
         raw_blob::Model {
             id: generate_id(),
-            sha1: value.id.to_plain_str(),
+            sha1: value.id.to_string(),
             storage_type: StorageType::Database,
             data: Some(value.data),
             content: None,

--- a/mercury/src/internal/model/commit.rs
+++ b/mercury/src/internal/model/commit.rs
@@ -50,12 +50,12 @@ impl From<Commit> for mega_commit::Model {
     fn from(value: Commit) -> Self {
         mega_commit::Model {
             id: generate_id(),
-            commit_id: value.id.to_plain_str(),
-            tree: value.tree_id.to_plain_str(),
+            commit_id: value.id.to_string(),
+            tree: value.tree_id.to_string(),
             parents_id: value
                 .parent_commit_ids
                 .iter()
-                .map(|x| x.to_plain_str())
+                .map(|x| x.to_string())
                 .collect(),
             author: Some(String::from_utf8_lossy(&value.author.to_data().unwrap()).to_string()),
             committer: Some(
@@ -72,12 +72,12 @@ impl From<Commit> for git_commit::Model {
         git_commit::Model {
             id: generate_id(),
             repo_id: 0,
-            commit_id: value.id.to_plain_str(),
-            tree: value.tree_id.to_plain_str(),
+            commit_id: value.id.to_string(),
+            tree: value.tree_id.to_string(),
             parents_id: value
                 .parent_commit_ids
                 .iter()
-                .map(|x| x.to_plain_str())
+                .map(|x| x.to_string())
                 .collect(),
             author: Some(String::from_utf8_lossy(&value.author.to_data().unwrap()).to_string()),
             committer: Some(

--- a/mercury/src/internal/model/tag.rs
+++ b/mercury/src/internal/model/tag.rs
@@ -12,8 +12,8 @@ impl From<Tag> for mega_tag::Model {
     fn from(value: Tag) -> Self {
         mega_tag::Model {
             id: generate_id(),
-            tag_id: value.id.to_plain_str(),
-            object_id: value.object_hash.to_plain_str(),
+            tag_id: value.id.to_string(),
+            object_id: value.object_hash.to_string(),
             object_type: value.object_type.to_string(),
             tag_name: value.tag_name,
             tagger: String::from_utf8_lossy(&value.tagger.to_data().unwrap()).to_string(),
@@ -28,8 +28,8 @@ impl From<Tag> for git_tag::Model {
         git_tag::Model {
             id: generate_id(),
             repo_id: 0,
-            tag_id: value.id.to_plain_str(),
-            object_id: value.object_hash.to_plain_str(),
+            tag_id: value.id.to_string(),
+            object_id: value.object_hash.to_string(),
             object_type: value.object_type.to_string(),
             tag_name: value.tag_name,
             tagger: String::from_utf8_lossy(&value.tagger.to_data().unwrap()).to_string(),

--- a/mercury/src/internal/model/tree.rs
+++ b/mercury/src/internal/model/tree.rs
@@ -10,7 +10,7 @@ impl From<Tree> for mega_tree::Model {
     fn from(value: Tree) -> Self {
         mega_tree::Model {
             id: generate_id(),
-            tree_id: value.id.to_plain_str(),
+            tree_id: value.id.to_string(),
             sub_trees: value.to_data().unwrap(),
             size: 0,
             commit_id: String::new(),
@@ -25,7 +25,7 @@ impl From<Tree> for git_tree::Model {
         git_tree::Model {
             id: generate_id(),
             repo_id: 0,
-            tree_id: value.id.to_plain_str(),
+            tree_id: value.id.to_string(),
             sub_trees: value.to_data().unwrap(),
             size: 0,
             commit_id: String::new(),

--- a/mercury/src/internal/object/commit.rs
+++ b/mercury/src/internal/object/commit.rs
@@ -194,12 +194,12 @@ impl ObjectTrait for Commit {
         let mut data = Vec::new();
 
         data.extend(b"tree ");
-        data.extend(self.tree_id.to_plain_str().as_bytes());
+        data.extend(self.tree_id.to_string().as_bytes());
         data.extend(&[0x0a]);
 
         for parent_tree_id in &self.parent_commit_ids {
             data.extend(b"parent ");
-            data.extend(parent_tree_id.to_plain_str().as_bytes());
+            data.extend(parent_tree_id.to_string().as_bytes());
             data.extend(&[0x0a]);
         }
 

--- a/mercury/src/internal/object/tag.rs
+++ b/mercury/src/internal/object/tag.rs
@@ -155,7 +155,7 @@ impl ObjectTrait for Tag {
 
         data.extend_from_slice("object".as_bytes());
         data.extend_from_slice(0x20u8.to_be_bytes().as_ref());
-        data.extend_from_slice(self.object_hash.to_plain_str().as_bytes());
+        data.extend_from_slice(self.object_hash.to_string().as_bytes());
         data.extend_from_slice(0x0au8.to_be_bytes().as_ref());
 
         data.extend_from_slice("type".as_bytes());

--- a/mercury/src/internal/object/tree.rs
+++ b/mercury/src/internal/object/tree.rs
@@ -349,7 +349,7 @@ mod tests {
 
         assert_eq!(tree_item.mode, TreeItemMode::Blob);
         assert_eq!(
-            tree_item.id.to_plain_str(),
+            tree_item.id.to_string(),
             "8ab686eafeb1f44702738c8b0f24f2567c36da6d"
         );
     }
@@ -385,7 +385,7 @@ mod tests {
         let tree_item = TreeItem::from_bytes(bytes.as_slice()).unwrap();
 
         assert_eq!(tree_item.mode, TreeItemMode::Blob);
-        assert_eq!(tree_item.id.to_plain_str(), item.id.to_plain_str());
+        assert_eq!(tree_item.id.to_string(), item.id.to_string());
     }
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
         println!("{}", tree.id);
         assert_eq!(
             "cf99336fa61439a2f074c7e6de1c1a05579550e2",
-            tree.id.to_plain_str()
+            tree.id.to_string()
         );
     }
 }

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -44,7 +44,7 @@ impl Caches {
     /// only get object from memory, not from tmp file
     fn try_get(&self, hash: SHA1) -> Option<Arc<CacheObject>> {
         let mut map = self.lru_cache.lock().unwrap();
-        map.get(&hash.to_plain_str()).map(|x| x.data.clone())
+        map.get(&hash.to_string()).map(|x| x.data.clone())
     }
 
     /// !IMPORTANT: because of the process of pack, the file must be written / be writing before, so it won't be dead lock
@@ -72,18 +72,18 @@ impl Caches {
             Some(self.pool.clone()),
         );
         x.set_store_path(Caches::generate_temp_path(&self.tmp_path, hash));
-        let _ = map.insert(hash.to_plain_str(), x); // handle the error
+        let _ = map.insert(hash.to_string(), x); // handle the error
         Ok(obj)
     }
 
     /// generate the temp file path, hex string of the hash
     fn generate_temp_path(tmp_path: &Path, hash: SHA1) -> PathBuf {
         let mut path = tmp_path.to_path_buf();
-        path.push(&hash.to_plain_str()[..2]); // use first 2 chars as the directory
+        path.push(&hash.to_string()[..2]); // use first 2 chars as the directory
         if !path.exists() {
             fs::create_dir(&path).unwrap();
         }
-        path.push(hash.to_plain_str());
+        path.push(hash.to_string());
         path
     }
 
@@ -154,7 +154,7 @@ impl _Cache for Caches {
                 Some(self.pool.clone()),
             );
             a_obj.set_store_path(Caches::generate_temp_path(&self.tmp_path, hash));
-            let _ = map.insert(hash.to_plain_str(), a_obj);
+            let _ = map.insert(hash.to_string(), a_obj);
         }
         //order maters as for reading in 'get_by_offset()'
         self.hash_set.insert(hash);

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -333,14 +333,14 @@ mod test {
         };
         {
             let r = cache.insert(
-                a.hash.to_plain_str(),
+                a.hash.to_string(),
                 ArcWrapper::new(Arc::new(a.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_ok())
         }
         {
             let r = cache.try_insert(
-                b.clone().hash.to_plain_str(),
+                b.clone().hash.to_string(),
                 ArcWrapper::new(Arc::new(b.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_err());
@@ -350,14 +350,14 @@ mod test {
                 panic!("Expected WouldEjectLru error");
             }
             let r = cache.insert(
-                b.hash.to_plain_str(),
+                b.hash.to_string(),
                 ArcWrapper::new(Arc::new(b.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_ok());
         }
         {
             // a should be ejected
-            let r = cache.get(&a.hash.to_plain_str());
+            let r = cache.get(&a.hash.to_string());
             assert!(r.is_none());
         }
     }

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -433,8 +433,8 @@ impl Pack {
         if render_hash != self.signature {
             return Err(GitError::InvalidPackFile(format!(
                 "The pack file hash {} does not match the trailer hash {}",
-                render_hash.to_plain_str(),
-                self.signature.to_plain_str()
+                render_hash,
+                self.signature
             )));
         }
 
@@ -726,7 +726,7 @@ mod tests {
         let mut buffered = BufReader::new(f);
         let mut p = Pack::new(Some(20), Some(1024*1024*1024*2), Some(tmp.clone()), true);
         let rt = p.decode(&mut buffered, |_obj, _offset|{
-            // println!("{:?} {}", obj.hash.to_plain_str(), offset);
+            // println!("{:?} {}", obj.hash.to_string(), offset);
         });
         if let Err(e) = rt {
             fs::remove_dir_all(tmp).unwrap();

--- a/mercury/src/internal/pack/utils.rs
+++ b/mercury/src/internal/pack/utils.rs
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_calc_obj_hash() {
         let hash = calculate_object_hash(ObjectType::Blob, &b"a".to_vec());
-        assert_eq!(hash.to_plain_str(), "2e65efe2a145dda7ee51d1741299f848e5bf752e");
+        assert_eq!(hash.to_string(), "2e65efe2a145dda7ee51d1741299f848e5bf752e");
     }
 
     #[test]

--- a/scorpio/src/manager/fetch.rs
+++ b/scorpio/src/manager/fetch.rs
@@ -32,7 +32,7 @@ impl CheckHash for ScorpioManager{
                 let p = GPath::from(work.path.to_string());
                 // Get the tree and its hash value, for name dictionary .
                 let tree = fetch_tree(&p).await.unwrap();
-                work.hash = tree.id.to_plain_str();
+                work.hash = tree.id.to_string();
                 // the lower path is store file path for remote code version . 
                 let _lower = PathBuf::from(&self.store_path).join(&work.hash).join("lower");
                 handlers.push(tokio::spawn(async move { fetch_code(&p, _lower).await }));
@@ -56,9 +56,9 @@ impl CheckHash for ScorpioManager{
         let workdir = WorkDir{
             path: p.to_string(),
             node:inode,
-            hash: tree.id.to_plain_str(),
+            hash: tree.id.to_string(),
         };
-        //work.hash = tree.id.to_plain_str();
+        //work.hash = tree.id.to_string();
         // the lower path is store file path for remote code version . 
         let _lower = PathBuf::from(&self.store_path).join(&workdir.hash).join("lower");
         fetch_code(&p, _lower).await;
@@ -76,9 +76,9 @@ pub async fn fetch<P: AsRef<Path>>(manager:&mut ScorpioManager,inode:u64,monopat
     let workdir = WorkDir{
         path: p.to_string(),
         node:inode,
-        hash: tree.id.to_plain_str(),
+        hash: tree.id.to_string(),
     };
-    //work.hash = tree.id.to_plain_str();
+    //work.hash = tree.id.to_string();
     // the lower path is store file path for remote code version . 
     let _lower = PathBuf::from(manager.store_path.clone()).join(&workdir.hash).join("lower");
     fetch_code(&p, _lower).await;
@@ -296,7 +296,7 @@ async fn fetch_code(path:&GPath, save_path : impl AsRef<Path>){
 
 async fn fetch_and_save_file(url: &SHA1, save_path: impl AsRef<Path>) -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
-     let url = format!("http://localhost:8000/api/v1/file/blob/{}",url.to_plain_str());//TODO: configabel.
+     let url = format!("http://localhost:8000/api/v1/file/blob/{}",url);//TODO: configabel.
     // Send GET request
     let response = client.get(url).send().await?;
     

--- a/scorpio/src/manager/mod.rs
+++ b/scorpio/src/manager/mod.rs
@@ -67,7 +67,7 @@ impl ScorpioManager {
         let mut data = BytesMut::new();
         add_pkt_line_string(&mut data, format!("{} {} {}\0report-status\n",
                                             work_dir.hash,
-                                            commit.id.to_plain_str(),
+                                            commit.id,
                                             "refs/heads/main"));//TODO : configable
         data.extend_from_slice(b"0000");
         data.extend(pack(commit.clone(),trees,blobs).await);

--- a/scorpio/src/manager/push.rs
+++ b/scorpio/src/manager/push.rs
@@ -64,8 +64,8 @@ pub async fn push(path:PathBuf,monopath:PathBuf){
         "test commit ");
     let mut data = BytesMut::new();
     add_pkt_line_string(&mut data, format!("{} {} {}\0report-status\n",
-                                           remote_hash.to_plain_str(),
-                                           commit.id.to_plain_str(),
+                                           remote_hash,
+                                           commit.id,
                                            "refs/heads/main"));
     data.extend_from_slice(b"0000");
     tracing::debug!("{:?}", data);


### PR DESCRIPTION
Refactoring: Removed the `Hash` struct `:: to_plain_str` function and replaced it with a standard to_string.
Now if you want to convert a hash to a string, you can call `to_string` instead of the previous `to_plain_str`. As an alternative, I've added `to_color_str` functions that can simply beautify the output of the hash value. This PR solves the previous API design flaw, which may bring the risk of error in string conversion.