### PR TITLE
refactor(mercury): remove sha1_smol dependency

### DIFF
--- a/mercury/Cargo.toml
+++ b/mercury/Cargo.toml
@@ -23,7 +23,6 @@ colored = { workspace = true }
 chrono = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-sha1_smol = "1.0.0"
 threadpool = "1.8.1"
 num_cpus.workspace = true
 dashmap = "6.0.1"


### PR DESCRIPTION
There are two different SHA1 implementations (*i.e.* `sha1` and `sha1_smol`) and a custom SHA1 Wrapper exist simultaneously in the codebase, which doesn't make sense. 
Since `sha1` is more widely used across the project, it should be kept in favor of `sha1_smol`.