### PR TITLE
fix(mercury): fix a crash when decoding without memory limit again

### DIFF
--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -162,7 +162,9 @@ impl _Cache for Caches {
                 self.complete_signal.clone(),
                 Some(self.pool.clone()),
             );
-            a_obj.set_store_path(self.generate_temp_path(&self.tmp_path, hash));
+            if self.mem_size.is_some() {
+                a_obj.set_store_path(self.generate_temp_path(&self.tmp_path, hash));
+            }
             let _ = map.insert(hash, a_obj);
         }
         //order maters as for reading in 'get_by_offset()'


### PR DESCRIPTION
Part of the fix in #746 was somehow reverted by 0c23c94d6e7c00ac9757bac719dbeb22d0e40d8d. This pr will bring it back.