### PR TITLE
fix(mercury): fix memory recorder for delta objects

### DIFF
--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -9,9 +9,9 @@ use lru_mem::{HeapSize, MemSize};
 use serde::{Deserialize, Serialize};
 use threadpool::ThreadPool;
 
+use crate::internal::pack::entry::Entry;
 use crate::internal::pack::utils;
 use crate::{hash::SHA1, internal::object::types::ObjectType};
-use crate::internal::pack::entry::Entry;
 
 // /// record heap-size of all CacheObjects, used for memory limit.
 // static CACHE_OBJS_MEM_SIZE: AtomicUsize = AtomicUsize::new(0);
@@ -56,7 +56,14 @@ pub struct CacheObject {
     pub data_decompress: Vec<u8>,
     pub offset: usize,
     pub hash: SHA1,
-    pub mem_recorder: Option<Arc<AtomicUsize>> // record mem-size of all CacheObjects of a Pack
+    /// If a [`CacheObject`] is an [`ObjectType::HashDelta`] or an [`ObjectType::OffsetDelta`],
+    /// it will expand to another [`CacheObject`] of other types. To prevent potential OOM,
+    /// we record the size of the expanded object as well as that of the object itself.
+    /// 
+    /// See https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481 for more details.
+    #[serde(skip, default = "usize::default")]
+    pub final_size: usize,
+    pub mem_recorder: Option<Arc<AtomicUsize>>, // record mem-size of all CacheObjects of a Pack
 }
 
 impl Clone for CacheObject {
@@ -68,6 +75,7 @@ impl Clone for CacheObject {
             data_decompress: self.data_decompress.clone(),
             offset: self.offset,
             hash: self.hash,
+            final_size: self.final_size,
             mem_recorder: self.mem_recorder.clone(),
         };
         obj.record_mem_size();
@@ -87,6 +95,7 @@ impl Default for CacheObject {
             obj_type: ObjectType::Blob,
             offset: 0,
             hash: SHA1::default(),
+            final_size: 0,
             mem_recorder: None,
         };
         obj.record_mem_size();
@@ -98,8 +107,11 @@ impl Default for CacheObject {
 // ! the implementation of HeapSize is not accurate, only calculate the size of the data_decompress
 // Note that: mem_size == value_size + heap_size, and we only need to impl HeapSize because value_size is known
 impl HeapSize for CacheObject {
+    /// For [`ObjectType::OffsetDelta`] and [`ObjectType::HashDelta`], 
+    /// `final_size` is the size of the expanded object;
+    /// for other types, `final_size` is 0.
     fn heap_size(&self) -> usize {
-        self.data_decompress.heap_size()
+        self.data_decompress.heap_size() + self.final_size
     }
 }
 
@@ -111,7 +123,6 @@ impl Drop for CacheObject {
         if let Some(mem_recorder) = &self.mem_recorder {
             mem_recorder.fetch_sub((*self).mem_size(), Ordering::SeqCst);
         }
-
     }
 }
 
@@ -146,7 +157,7 @@ impl MemSizeRecorder for CacheObject {
 }
 
 impl CacheObject {
-    /// Create a new CacheObject witch is not offset_delta or hash_delta
+    /// Create a new CacheObject which is neither [`ObjectType::OffsetDelta`] nor [`ObjectType::HashDelta`].
     pub fn new_for_undeltified(obj_type: ObjectType, data: Vec<u8>, offset: usize) -> Self {
         let hash = utils::calculate_object_hash(obj_type, &data);
         CacheObject {
@@ -154,6 +165,7 @@ impl CacheObject {
             obj_type,
             offset,
             hash,
+            final_size: 0, // Only delta objects have final_size
             mem_recorder: None,
             ..Default::default()
         }
@@ -162,13 +174,11 @@ impl CacheObject {
     /// transform the CacheObject to Entry
     pub fn to_entry(&self) -> Entry {
         match self.obj_type {
-            ObjectType::Blob | ObjectType::Tree | ObjectType::Commit | ObjectType::Tag => {
-                Entry {
-                    obj_type: self.obj_type,
-                    data: self.data_decompress.clone(),
-                    hash: self.hash,
-                }
-            }
+            ObjectType::Blob | ObjectType::Tree | ObjectType::Commit | ObjectType::Tag => Entry {
+                obj_type: self.obj_type,
+                data: self.data_decompress.clone(),
+                hash: self.hash,
+            },
             _ => {
                 unreachable!("delta object should not persist!")
             }
@@ -177,10 +187,16 @@ impl CacheObject {
 }
 
 /// trait alias for simple use
-pub trait ArcWrapperBounds: HeapSize + Serialize + for<'a> Deserialize<'a> + Send + Sync + 'static {}
+pub trait ArcWrapperBounds:
+    HeapSize + Serialize + for<'a> Deserialize<'a> + Send + Sync + 'static
+{
+}
 // You must impl `Alias Trait` for all the `T` satisfying Constraints
 // Or, `T` will not satisfy `Alias Trait` even if it satisfies the Original traits
-impl<T: HeapSize + Serialize + for<'a> Deserialize<'a> + Send + Sync + 'static> ArcWrapperBounds for T {}
+impl<T: HeapSize + Serialize + for<'a> Deserialize<'a> + Send + Sync + 'static> ArcWrapperBounds
+    for T
+{
+}
 
 /// Implementing encapsulation of Arc to enable third-party Trait HeapSize implementation for the Arc type
 /// Because of use Arc in LruCache, the LruCache is not clear whether a pointer will drop the referenced
@@ -300,6 +316,7 @@ mod test {
             obj_type: ObjectType::Blob,
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
+            final_size: 0,
             mem_recorder: None,
         };
         assert!(a.heap_size() == 1024);
@@ -318,6 +335,7 @@ mod test {
             obj_type: ObjectType::Blob,
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
+            final_size: 0,
             mem_recorder: None,
         };
         println!("a.heap_size() = {}", a.heap_size());
@@ -329,6 +347,7 @@ mod test {
             obj_type: ObjectType::Blob,
             offset: 0,
             hash: SHA1::new(&vec![1; 20]),
+            final_size: 0,
             mem_recorder: None,
         };
         {
@@ -433,6 +452,7 @@ mod test {
             obj_type: ObjectType::Blob,
             offset: 0,
             hash: SHA1::new(&vec![0; 20]),
+            final_size: 0,
             mem_recorder: None,
         };
         let s = bincode::serialize(&a).unwrap();

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -60,7 +60,7 @@ pub struct CacheObject {
     /// it will expand to another [`CacheObject`] of other types. To prevent potential OOM,
     /// we record the size of the expanded object as well as that of the object itself.
     /// 
-    /// See https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481 for more details.
+    /// See [Comment in PR #755](https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481) for more details.
     #[serde(skip, default = "usize::default")]
     pub final_size: usize,
     pub mem_recorder: Option<Arc<AtomicUsize>>, // record mem-size of all CacheObjects of a Pack

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -350,13 +350,14 @@ impl Pack {
         let mut offset: usize = 12;
         let mut i = 0;
         while i < self.number {
-            // log per 2000&more then 1 se objects
+            // log per 1000 objects and 1 second
+            if i%1000 == 0 {
                 let time_now = time.elapsed().as_millis();
                 if time_now - last_update_time > 1000 {
                     log_info(i, self);
                     last_update_time = time_now;
                 }
-            
+            }
             // 3 parts: Waitlist + TheadPool + Caches
             // hardcode the limit of the tasks of threads_pool queue, to limit memory
             while self.pool.queued_count() > 2000 

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -283,7 +283,7 @@ impl Pack {
                     data_decompress: data,
                     obj_type: t,
                     offset: init_offset,
-                    final_size,
+                    delta_final_size: final_size,
                     mem_recorder: None,
                     ..Default::default()
                 })
@@ -305,7 +305,7 @@ impl Pack {
                     data_decompress: data,
                     obj_type: t,
                     offset: init_offset,
-                    final_size,
+                    delta_final_size: final_size,
                     mem_recorder: None,
                     ..Default::default()
                 })
@@ -314,8 +314,6 @@ impl Pack {
     }
 
     /// Decodes a pack file from a given Read and BufRead source and get a vec of objects.
-    ///
-    ///
     pub fn decode<F>(&mut self, pack: &mut (impl BufRead + Send), callback: F) -> Result<(), GitError>
     where
         F: Fn(Entry, usize) + Sync + Send + 'static
@@ -612,7 +610,7 @@ impl Pack {
             data_decompress: result,
             obj_type: base_obj.obj_type, // Same as the Type of base object
             hash,
-            final_size: 0, // The new object is not a delta obj, so set its final size to 0.
+            delta_final_size: 0, // The new object is not a delta obj, so set its final size to 0.
             mem_recorder: None, // This filed(Arc) can't be moved from `delta_obj` by `struct update syntax`
             ..delta_obj // This syntax is actually move `delta_obj` to `new_obj`
         } // Canonical form (Complete Object)

--- a/mercury/src/internal/pack/utils.rs
+++ b/mercury/src/internal/pack/utils.rs
@@ -153,8 +153,6 @@ pub fn read_varint_le<R: Read>(reader: &mut R) -> io::Result<(u64, usize)> {
     Ok((value, offset))
 }
 
-
-
 /// The offset for an OffsetDelta object(big-endian order)
 /// # Arguments
 ///
@@ -230,6 +228,26 @@ pub fn read_partial_int<R: Read>(
     }
 
     Ok(value)
+}
+
+/// Reads the base size and result size of a delta object from the given stream.
+/// 
+/// **Note**: The stream MUST be positioned at the start of the delta object.
+/// 
+/// The base size and result size are encoded as variable-length integers in little-endian order.
+/// 
+/// The base size is the size of the base object, and the result size is the size of the result object.
+/// 
+/// # Parameters
+/// * `stream`: The stream from which the sizes are read.
+/// 
+/// # Returns
+/// Returns a tuple containing the base size and result size.
+/// 
+pub fn read_delta_object_size<R: Read>(stream: &mut R) -> io::Result<(usize, usize)> {
+    let base_size = read_varint_le(stream)?.0 as usize;
+    let result_size = read_varint_le(stream)?.0 as usize;
+    Ok((base_size, result_size))
 }
 
 /// Calculate the SHA1 hash of the given object.


### PR DESCRIPTION
Sorry for the disturbance. This patch should preserve the functionality of memory recorder while improving the performance.

Context: https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481