### PR TITLE
refactor(mercury): introduce CachedObjectInfo for better clarity…

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -536,22 +536,22 @@ mod test {
         let base = Tree::from_tree_items(vec![
             TreeItem {
                 mode: TreeItemMode::Tree,
-                id: SHA1::new(&"src".as_bytes().to_vec()),
+                id: SHA1::new(b"src"),
                 name: "src".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Tree,
-                id: SHA1::new(&"mega".as_bytes().to_vec()),
+                id: SHA1::new(b"mega"),
                 name: "mega".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Blob,
-                id: SHA1::new(&"delete.txt".as_bytes().to_vec()),
+                id: SHA1::new(b"delete.txt"),
                 name: "delete.txt".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Blob,
-                id: SHA1::new(&"README.md".as_bytes().to_vec()),
+                id: SHA1::new(b"README.md"),
                 name: "README.md".to_string(),
             },
         ])
@@ -560,22 +560,22 @@ mod test {
         let new = Tree::from_tree_items(vec![
             TreeItem {
                 mode: TreeItemMode::Tree,
-                id: SHA1::new(&"src".as_bytes().to_vec()),
+                id: SHA1::new(b"src"),
                 name: "src_new".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Tree,
-                id: SHA1::new(&"mega222".as_bytes().to_vec()),
+                id: SHA1::new(b"mega222"),
                 name: "mega".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Blob,
-                id: SHA1::new(&"Cargo.toml".as_bytes().to_vec()),
+                id: SHA1::new(b"Cargo.toml"),
                 name: "Cargo.toml".to_string(),
             },
             TreeItem {
                 mode: TreeItemMode::Blob,
-                id: SHA1::new(&"README.md".as_bytes().to_vec()),
+                id: SHA1::new(b"README.md"),
                 name: "README.md".to_string(),
             },
         ])

--- a/libra/src/command/fetch.rs
+++ b/libra/src/command/fetch.rs
@@ -180,7 +180,7 @@ pub async fn fetch_repository(remote_config: &RemoteConfig, branch: Option<Strin
 
     /* save pack file */
     let pack_file = {
-        let hash = SHA1::new(&pack_data[..pack_data.len() - 20].to_vec());
+        let hash = SHA1::new(&pack_data[..pack_data.len() - 20]);
 
         let checksum = SHA1::from_bytes(&pack_data[pack_data.len() - 20..]);
         assert_eq!(hash, checksum);

--- a/libra/src/command/log.rs
+++ b/libra/src/command/log.rs
@@ -161,28 +161,28 @@ mod tests {
     //           \  / \
     ///            4   7
     async fn create_test_commit_tree() -> String {
-        let mut commit_1 = Commit::from_tree_id(SHA1::new(&vec![1; 20]), vec![], "Commit_1");
+        let mut commit_1 = Commit::from_tree_id(SHA1::new(&[1; 20]), vec![], "Commit_1");
         commit_1.committer.timestamp = 1;
         // save_object(&commit_1);
         save_object(&commit_1, &commit_1.id).unwrap();
 
         let mut commit_2 =
-            Commit::from_tree_id(SHA1::new(&vec![2; 20]), vec![commit_1.id], "Commit_2");
+            Commit::from_tree_id(SHA1::new(&[2; 20]), vec![commit_1.id], "Commit_2");
         commit_2.committer.timestamp = 2;
         save_object(&commit_2, &commit_2.id).unwrap();
 
         let mut commit_3 =
-            Commit::from_tree_id(SHA1::new(&vec![3; 20]), vec![commit_2.id], "Commit_3");
+            Commit::from_tree_id(SHA1::new(&[3; 20]), vec![commit_2.id], "Commit_3");
         commit_3.committer.timestamp = 3;
         save_object(&commit_3, &commit_3.id).unwrap();
 
         let mut commit_4 =
-            Commit::from_tree_id(SHA1::new(&vec![4; 20]), vec![commit_2.id], "Commit_4");
+            Commit::from_tree_id(SHA1::new(&[4; 20]), vec![commit_2.id], "Commit_4");
         commit_4.committer.timestamp = 4;
         save_object(&commit_4, &commit_4.id).unwrap();
 
         let mut commit_5 = Commit::from_tree_id(
-            SHA1::new(&vec![5; 20]),
+            SHA1::new(&[5; 20]),
             vec![commit_2.id, commit_4.id],
             "Commit_5",
         );
@@ -190,7 +190,7 @@ mod tests {
         save_object(&commit_5, &commit_5.id).unwrap();
 
         let mut commit_6 = Commit::from_tree_id(
-            SHA1::new(&vec![6; 20]),
+            SHA1::new(&[6; 20]),
             vec![commit_3.id, commit_5.id],
             "Commit_6",
         );
@@ -198,7 +198,7 @@ mod tests {
         save_object(&commit_6, &commit_6.id).unwrap();
 
         let mut commit_7 =
-            Commit::from_tree_id(SHA1::new(&vec![7; 20]), vec![commit_5.id], "Commit_7");
+            Commit::from_tree_id(SHA1::new(&[7; 20]), vec![commit_5.id], "Commit_7");
         commit_7.committer.timestamp = 7;
         save_object(&commit_7, &commit_7.id).unwrap();
 

--- a/libra/src/command/mod.rs
+++ b/libra/src/command/mod.rs
@@ -135,7 +135,7 @@ mod test {
     #[tokio::test]
     async fn test_save_load_object() {
         test::setup_with_new_libra().await;
-        let object = Commit::from_tree_id(SHA1::new(&vec![1; 20]), vec![], "Commit_1");
+        let object = Commit::from_tree_id(SHA1::new(&[1; 20]), vec![], "Commit_1");
         save_object(&object, &object.id).unwrap();
         let _ = load_object::<Commit>(&object.id).unwrap();
     }

--- a/libra/src/utils/client_storage.rs
+++ b/libra/src/utils/client_storage.rs
@@ -237,7 +237,7 @@ impl ClientStorage {
         for idx in idxes {
             let res = Self::read_pack_by_idx(&idx, obj_id)?;
             if let Some(data) = res {
-                return Ok(Some((data.data_decompress.clone(), data.object_type())));
+                return Ok(Some((data.data_decompressed.clone(), data.object_type())));
             }
         }
 

--- a/mercury/src/hash.rs
+++ b/mercury/src/hash.rs
@@ -155,7 +155,7 @@ mod tests {
         let data = "Hello, world!".as_bytes();
 
         // Generate SHA1 hash from the input data
-        let sha1 = SHA1::new(&data.to_vec());
+        let sha1 = SHA1::new(&data);
 
         // Known SHA1 hash for "Hello, world!"
         let expected_sha1_hash = "943a702d06f34599aee1f8da8ef9f7296031d699";

--- a/mercury/src/hash.rs
+++ b/mercury/src/hash.rs
@@ -95,8 +95,8 @@ impl SHA1 {
     // The size of the SHA-1 hash value in bytes
     pub const SIZE: usize = 20;
 
-    /// Calculate the SHA-1 hash of `Vec<u8>` data, then create a Hash value
-    pub fn new(data: &Vec<u8>) -> SHA1 {
+    /// Calculate the SHA-1 hash of the byte slice, then create a Hash value
+    pub fn new(data: &[u8]) -> SHA1 {
         let h = sha1::Sha1::digest(data);
         SHA1::from_bytes(h.as_slice())
     }

--- a/mercury/src/hash.rs
+++ b/mercury/src/hash.rs
@@ -155,7 +155,7 @@ mod tests {
         let data = "Hello, world!".as_bytes();
 
         // Generate SHA1 hash from the input data
-        let sha1 = SHA1::new(&data);
+        let sha1 = SHA1::new(data);
 
         // Known SHA1 hash for "Hello, world!"
         let expected_sha1_hash = "943a702d06f34599aee1f8da8ef9f7296031d699";

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -97,7 +97,7 @@ impl Caches {
     }
 
     fn read_from_temp(path: &Path) -> io::Result<CacheObject> {
-        let obj = CacheObject::f_load(&path)?;
+        let obj = CacheObject::f_load(path)?;
         // Deserializing will also create an object but without Construction outside and `::new()`
         // So if you want to do sth. while Constructing, impl Deserialize trait yourself
         obj.record_mem_size();
@@ -236,8 +236,8 @@ mod test {
     fn test_cache_single_thread() {
         let source = PathBuf::from(env::current_dir().unwrap().parent().unwrap());
         let cache = Caches::new(Some(2048), source.clone().join("tests/.cache_tmp"), 1);
-        let a_hash = SHA1::new(&String::from("a").into_bytes());
-        let b_hash = SHA1::new(&String::from("b").into_bytes());
+        let a_hash = SHA1::new(String::from("a").as_bytes());
+        let b_hash = SHA1::new(String::from("b").as_bytes());
         let a = CacheObject {
             info: CachedObjectInfo::BaseObject(ObjectType::Blob, a_hash),
             data_decompressed: vec![0; 1024],
@@ -266,7 +266,7 @@ mod test {
         assert!(cache.try_get(a_hash).is_some());
         assert!(cache.try_get(b_hash).is_none());
 
-        let c_hash = SHA1::new(&String::from("c").into_bytes());
+        let c_hash = SHA1::new(String::from("c").as_bytes());
         // insert too large c, a will still be in the cache
         let c = CacheObject {
             info: CachedObjectInfo::BaseObject(ObjectType::Blob, c_hash),

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -230,7 +230,7 @@ mod test {
     use std::env;
 
     use super::*;
-    use crate::{hash::SHA1, internal::{object::types::ObjectType, pack::cache_object::CachedObjectInfo}};
+    use crate::{hash::SHA1, internal::{object::types::ObjectType, pack::cache_object::CacheObjectInfo}};
 
     #[test]
     fn test_cache_single_thread() {
@@ -239,14 +239,14 @@ mod test {
         let a_hash = SHA1::new(String::from("a").as_bytes());
         let b_hash = SHA1::new(String::from("b").as_bytes());
         let a = CacheObject {
-            info: CachedObjectInfo::BaseObject(ObjectType::Blob, a_hash),
-            data_decompressed: vec![0; 1024],
+            info: CacheObjectInfo::BaseObject(ObjectType::Blob, a_hash),
+            data_decompress: vec![0; 1024],
             mem_recorder: None,
             offset: 0,
         };
         let b = CacheObject {
-            info: CachedObjectInfo::BaseObject(ObjectType::Blob, b_hash),
-            data_decompressed: vec![0; 1636],
+            info: CacheObjectInfo::BaseObject(ObjectType::Blob, b_hash),
+            data_decompress: vec![0; 1636],
             mem_recorder: None,
             offset: 0,
         };
@@ -269,8 +269,8 @@ mod test {
         let c_hash = SHA1::new(String::from("c").as_bytes());
         // insert too large c, a will still be in the cache
         let c = CacheObject {
-            info: CachedObjectInfo::BaseObject(ObjectType::Blob, c_hash),
-            data_decompressed: vec![0; 2049],
+            info: CacheObjectInfo::BaseObject(ObjectType::Blob, c_hash),
+            data_decompress: vec![0; 2049],
             mem_recorder: None,
             offset: 0,
         };

--- a/mercury/src/internal/pack/cache.rs
+++ b/mercury/src/internal/pack/cache.rs
@@ -240,13 +240,13 @@ mod test {
         let b_hash = SHA1::new(String::from("b").as_bytes());
         let a = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, a_hash),
-            data_decompress: vec![0; 1024],
+            data_decompressed: vec![0; 1024],
             mem_recorder: None,
             offset: 0,
         };
         let b = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, b_hash),
-            data_decompress: vec![0; 1636],
+            data_decompressed: vec![0; 1636],
             mem_recorder: None,
             offset: 0,
         };
@@ -270,7 +270,7 @@ mod test {
         // insert too large c, a will still be in the cache
         let c = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, c_hash),
-            data_decompress: vec![0; 2049],
+            data_decompressed: vec![0; 2049],
             mem_recorder: None,
             offset: 0,
         };

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -48,55 +48,57 @@ impl<T: Serialize + for<'a> Deserialize<'a>> FileLoadStore for T {
         Ok(())
     }
 }
+
+/// Represents the metadata of a cache object, indicating whether it is a delta or not.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub enum CachedObjectInfo {
+    /// The object is one of the four basic types:
+    /// [`ObjectType::Blob`], [`ObjectType::Tree`], [`ObjectType::Commit`], or [`ObjectType::Tag`].
+    /// The metadata contains the [`ObjectType`] and the [`SHA1`] hash of the object.
+    BaseObject(ObjectType, SHA1),
+    /// The object is an offset delta with a specified offset delta [`usize`],
+    /// and the size of the expanded object (previously `delta_final_size`).
+    OffsetDelta(usize, usize),
+    /// The object is a hash delta with a specified [`SHA1`] hash,
+    /// and the size of the expanded object (previously `delta_final_size`).
+    HashDelta(SHA1, usize),
+}
+
+impl CachedObjectInfo {
+    /// Get the [`ObjectType`] of the object.
+    pub fn object_type(&self) -> ObjectType {
+        match self {
+            CachedObjectInfo::BaseObject(obj_type, _) => *obj_type,
+            CachedObjectInfo::OffsetDelta(_, _) => ObjectType::OffsetDelta,
+            CachedObjectInfo::HashDelta(_, _) => ObjectType::HashDelta,
+        }
+    }
+
+    /// If the object is one of the four basic types, return the [`SHA1`] hash of the object.
+    /// Otherwise, panic.
+    pub fn base_object_hash(&self) -> SHA1 {
+        match self {
+            CachedObjectInfo::BaseObject(_, hash) => *hash,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CacheObject {
-    pub base_offset: usize,
-    pub base_ref: SHA1,
-    pub obj_type: ObjectType,
+    pub info: CachedObjectInfo,
     pub data_decompress: Vec<u8>,
     pub offset: usize,
-    pub hash: SHA1,
-    /// If a [`CacheObject`] is an [`ObjectType::HashDelta`] or an [`ObjectType::OffsetDelta`],
-    /// it will expand to another [`CacheObject`] of other types. To prevent potential OOM,
-    /// we record the size of the expanded object as well as that of the object itself.
-    /// 
-    /// See [Comment in PR #755](https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481) for more details.
-    #[serde(skip, default = "usize::default")]
-    pub delta_final_size: usize,
     pub mem_recorder: Option<Arc<AtomicUsize>>, // record mem-size of all CacheObjects of a Pack
 }
 
 impl Clone for CacheObject {
     fn clone(&self) -> Self {
         let obj = CacheObject {
-            base_offset: self.base_offset,
-            base_ref: self.base_ref,
-            obj_type: self.obj_type,
+            info: self.info.clone(),
             data_decompress: self.data_decompress.clone(),
             offset: self.offset,
-            hash: self.hash,
-            delta_final_size: self.delta_final_size,
             mem_recorder: self.mem_recorder.clone(),
-        };
-        obj.record_mem_size();
-        obj
-    }
-}
-
-// For Convenience
-impl Default for CacheObject {
-    // It will be called in "struct update syntax": `..Default::default()`
-    // So, mem-record should happen here!
-    fn default() -> Self {
-        let obj = CacheObject {
-            base_offset: 0,
-            base_ref: SHA1::default(),
-            data_decompress: Vec::new(),
-            obj_type: ObjectType::Blob,
-            offset: 0,
-            hash: SHA1::default(),
-            delta_final_size: 0,
-            mem_recorder: None,
         };
         obj.record_mem_size();
         obj
@@ -107,21 +109,29 @@ impl Default for CacheObject {
 // ! the implementation of HeapSize is not accurate, only calculate the size of the data_decompress
 // Note that: mem_size == value_size + heap_size, and we only need to impl HeapSize because value_size is known
 impl HeapSize for CacheObject {
-    /// For [`ObjectType::OffsetDelta`] and [`ObjectType::HashDelta`], 
-    /// `delta_final_size` is the size of the expanded object;
-    /// for other types, `delta_final_size` is 0 as they won't expand.
+    /// If a [`CacheObject`] is an [`ObjectType::HashDelta`] or an [`ObjectType::OffsetDelta`],
+    /// it will expand to another [`CacheObject`] of other types. To prevent potential OOM,
+    /// we record the size of the expanded object as well as that of the object itself.
+    ///
+    /// See [Comment in PR #755](https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481) for more details.
     fn heap_size(&self) -> usize {
-        // To those who are concerned about why these two values are added,
-        // let's consider the lifetime of two `CacheObject`s, say `delta_obj`
-        // and `final_obj` in the function `Pack::rebuild_delta`. 
-        //
-        // `delta_obj` is dropped only after `Pack::rebuild_delta` returns,
-        // but the space for `final_obj` is allocated in that function.
-        //
-        // Therefore, during the execution of `Pack::rebuild_delta`, both `delta_obj`
-        // and `final_obj` coexist. The maximum memory usage is the sum of the memory
-        // usage of `delta_obj` and `final_obj`.
-        self.data_decompress.heap_size() + self.delta_final_size
+        match &self.info {
+            CachedObjectInfo::BaseObject(_, _) => self.data_decompress.heap_size(),
+            CachedObjectInfo::OffsetDelta(_, delta_final_size)
+            | CachedObjectInfo::HashDelta(_, delta_final_size) => {
+                // To those who are concerned about why these two values are added,
+                // let's consider the lifetime of two `CacheObject`s, say `delta_obj`
+                // and `final_obj` in the function `Pack::rebuild_delta`.
+                //
+                // `delta_obj` is dropped only after `Pack::rebuild_delta` returns,
+                // but the space for `final_obj` is allocated in that function.
+                //
+                // Therefore, during the execution of `Pack::rebuild_delta`, both `delta_obj`
+                // and `final_obj` coexist. The maximum memory usage is the sum of the memory
+                // usage of `delta_obj` and `final_obj`.
+                self.data_decompress.heap_size() + delta_final_size
+            }
+        }
     }
 }
 
@@ -171,23 +181,25 @@ impl CacheObject {
     pub fn new_for_undeltified(obj_type: ObjectType, data: Vec<u8>, offset: usize) -> Self {
         let hash = utils::calculate_object_hash(obj_type, &data);
         CacheObject {
+            info: CachedObjectInfo::BaseObject(obj_type, hash),
             data_decompress: data,
-            obj_type,
             offset,
-            hash,
-            delta_final_size: 0, // Only delta objects have `delta_final_size`
             mem_recorder: None,
-            ..Default::default()
         }
+    }
+
+    /// Get the [`ObjectType`] of the object.
+    pub fn object_type(&self) -> ObjectType {
+        self.info.object_type()
     }
 
     /// transform the CacheObject to Entry
     pub fn to_entry(&self) -> Entry {
-        match self.obj_type {
-            ObjectType::Blob | ObjectType::Tree | ObjectType::Commit | ObjectType::Tag => Entry {
-                obj_type: self.obj_type,
+        match self.info {
+            CachedObjectInfo::BaseObject(obj_type, hash) => Entry {
+                obj_type,
                 data: self.data_decompress.clone(),
-                hash: self.hash,
+                hash,
             },
             _ => {
                 unreachable!("delta object should not persist!")
@@ -304,9 +316,10 @@ mod test {
     // 只在单线程测试
     fn test_heap_size_record() {
         let mut obj = CacheObject {
+            info: CachedObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
             data_decompress: vec![0; 1024],
+            offset: 0,
             mem_recorder: None,
-            ..Default::default()
         };
         let mem = Arc::new(AtomicUsize::default());
         assert_eq!(mem.load(Ordering::Relaxed), 0);
@@ -320,13 +333,9 @@ mod test {
     #[test]
     fn test_cache_object_with_same_size() {
         let a = CacheObject {
-            base_offset: 0,
-            base_ref: SHA1::new(&vec![0; 20]),
+            info: CachedObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
             data_decompress: vec![0; 1024],
-            obj_type: ObjectType::Blob,
             offset: 0,
-            hash: SHA1::new(&vec![0; 20]),
-            delta_final_size: 0,
             mem_recorder: None,
         };
         assert!(a.heap_size() == 1024);
@@ -338,38 +347,32 @@ mod test {
     #[test]
     fn test_chache_object_with_lru() {
         let mut cache = LruCache::new(2048);
+        
+        let hash = SHA1::default();
         let a = CacheObject {
-            base_offset: 0,
-            base_ref: SHA1::new(&vec![0; 20]),
+            info: CachedObjectInfo::BaseObject(ObjectType::Blob, hash),
             data_decompress: vec![0; 1024],
-            obj_type: ObjectType::Blob,
             offset: 0,
-            hash: SHA1::new(&vec![0; 20]),
-            delta_final_size: 0,
             mem_recorder: None,
         };
         println!("a.heap_size() = {}", a.heap_size());
 
         let b = CacheObject {
-            base_offset: 0,
-            base_ref: SHA1::new(&vec![0; 20]),
+            info: CachedObjectInfo::BaseObject(ObjectType::Blob, hash),
             data_decompress: vec![0; (1024.0 * 1.5) as usize],
-            obj_type: ObjectType::Blob,
             offset: 0,
-            hash: SHA1::new(&vec![1; 20]),
-            delta_final_size: 0,
             mem_recorder: None,
         };
         {
             let r = cache.insert(
-                a.hash.to_string(),
+                hash.to_string(),
                 ArcWrapper::new(Arc::new(a.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_ok())
         }
         {
             let r = cache.try_insert(
-                b.clone().hash.to_string(),
+                hash.to_string(),
                 ArcWrapper::new(Arc::new(b.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_err());
@@ -379,14 +382,14 @@ mod test {
                 panic!("Expected WouldEjectLru error");
             }
             let r = cache.insert(
-                b.hash.to_string(),
+                hash.to_string(),
                 ArcWrapper::new(Arc::new(b.clone()), Arc::new(AtomicBool::new(true)), None),
             );
             assert!(r.is_ok());
         }
         {
             // a should be ejected
-            let r = cache.get(&a.hash.to_string());
+            let r = cache.get(&hash.to_string());
             assert!(r.is_none());
         }
     }
@@ -456,18 +459,16 @@ mod test {
     #[test]
     fn test_cache_object_serialize() {
         let a = CacheObject {
-            base_offset: 0,
-            base_ref: SHA1::new(&vec![0; 20]),
+            info: CachedObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
             data_decompress: vec![0; 1024],
-            obj_type: ObjectType::Blob,
             offset: 0,
-            hash: SHA1::new(&vec![0; 20]),
-            delta_final_size: 0,
             mem_recorder: None,
         };
         let s = bincode::serialize(&a).unwrap();
         let b: CacheObject = bincode::deserialize(&s).unwrap();
-        assert!(a.base_offset == b.base_offset);
+        assert_eq!(a.info, b.info);
+        assert_eq!(a.data_decompress, b.data_decompress);
+        assert_eq!(a.offset, b.offset);
     }
 
     #[test]

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -353,7 +353,7 @@ mod test {
         let mut cache = LruCache::new(2048);
         
         let hash_a = SHA1::default();
-        let hash_b = SHA1::new(&[b'b']); // whatever different hash
+        let hash_b = SHA1::new(b"b"); // whatever different hash
         let a = CacheObject {
             info: CachedObjectInfo::BaseObject(ObjectType::Blob, hash_a),
             offset: 0,

--- a/mercury/src/internal/pack/cache_object.rs
+++ b/mercury/src/internal/pack/cache_object.rs
@@ -78,7 +78,6 @@ impl CacheObjectInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CacheObject {
     pub(crate) info: CacheObjectInfo,
-    pub data_decompress: Vec<u8>,
     pub offset: usize,
     pub data_decompressed: Vec<u8>,
     pub mem_recorder: Option<Arc<AtomicUsize>>, // record mem-size of all CacheObjects of a Pack
@@ -112,7 +111,7 @@ impl HeapSize for CacheObject {
     /// See [Comment in PR #755](https://github.com/web3infra-foundation/mega/pull/755#issuecomment-2543100481) for more details.
     fn heap_size(&self) -> usize {
         match &self.info {
-            CacheObjectInfo::BaseObject(_, _) => self.data_decompress.heap_size(),
+            CacheObjectInfo::BaseObject(_, _) => self.data_decompressed.heap_size(),
             CacheObjectInfo::OffsetDelta(_, delta_final_size)
             | CacheObjectInfo::HashDelta(_, delta_final_size) => {
                 // To those who are concerned about why these two values are added,
@@ -178,7 +177,6 @@ impl CacheObject {
         let hash = utils::calculate_object_hash(obj_type, &data);
         CacheObject {
             info: CacheObjectInfo::BaseObject(obj_type, hash),
-            data_decompress: data,
             offset,
             data_decompressed: data,
             mem_recorder: None,
@@ -344,7 +342,6 @@ mod test {
     fn test_heap_size_record() {
         let mut obj = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
-            data_decompress: vec![0; 1024],
             offset: 0,
             data_decompressed: vec![0; 1024],
             mem_recorder: None,
@@ -362,7 +359,6 @@ mod test {
     fn test_cache_object_with_same_size() {
         let a = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
-            data_decompress: vec![0; 1024],
             offset: 0,
             data_decompressed: vec![0; 1024],
             mem_recorder: None,
@@ -381,7 +377,6 @@ mod test {
         let hash_b = SHA1::new(b"b"); // whatever different hash
         let a = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, hash_a),
-            data_decompress: vec![0; 1024],
             offset: 0,
             data_decompressed: vec![0; 1024],
             mem_recorder: None,
@@ -390,7 +385,6 @@ mod test {
 
         let b = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, hash_b),
-            data_decompress: vec![0; (1024.0 * 1.5) as usize],
             offset: 0,
             data_decompressed: vec![0; (1024.0 * 1.5) as usize],
             mem_recorder: None,
@@ -492,7 +486,6 @@ mod test {
     fn test_cache_object_serialize() {
         let a = CacheObject {
             info: CacheObjectInfo::BaseObject(ObjectType::Blob, SHA1::default()),
-            data_decompress: vec![0; 1024],
             offset: 0,
             data_decompressed: vec![0; 1024],
             mem_recorder: None,

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -282,7 +282,6 @@ impl Pack {
 
                 Ok(CacheObject {
                     info: CacheObjectInfo::OffsetDelta(base_offset, final_size),
-                    data_decompress: data,
                     offset: init_offset,
                     data_decompressed: data,
                     mem_recorder: None,
@@ -302,7 +301,6 @@ impl Pack {
 
                 Ok(CacheObject {
                     info: CacheObjectInfo::HashDelta(ref_sha1, final_size),
-                    data_decompress: data,
                     offset: init_offset,
                     data_decompressed: data,
                     mem_recorder: None,
@@ -604,7 +602,6 @@ impl Pack {
         // create new obj from `delta_obj` & `result` instead of modifying `delta_obj` for heap-size recording
         CacheObject {
             info: CacheObjectInfo::BaseObject(base_obj.object_type(), hash),
-            data_decompress: result,
             offset: delta_obj.offset,
             data_decompressed: result,
             mem_recorder: None,

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -738,7 +738,7 @@ mod tests {
         let stream = ReaderStream::new(f).map_err(|e| {
             axum::Error::new(e)
         });
-        let p = Pack::new(Some(20), None, Some(tmp.clone()), true);
+        let p = Pack::new(Some(20), Some(1024*1024*1024*4), Some(tmp.clone()), true);
 
         let (tx, rx) = std::sync::mpsc::channel();
         let (pack, _ ) = p.decode_stream(stream, 1024 * 1024 * 1024, tx).await;

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -282,8 +282,8 @@ impl Pack {
 
                 Ok(CacheObject {
                     info: CachedObjectInfo::OffsetDelta(base_offset, final_size),
-                    data_decompress: data,
                     offset: init_offset,
+                    data_decompressed: data,
                     mem_recorder: None,
                 })
             },
@@ -301,8 +301,8 @@ impl Pack {
 
                 Ok(CacheObject {
                     info: CachedObjectInfo::HashDelta(ref_sha1, final_size),
-                    data_decompress: data,
                     offset: init_offset,
+                    data_decompressed: data,
                     mem_recorder: None,
                 })
             }
@@ -534,14 +534,14 @@ impl Pack {
         const COPY_SIZE_BYTES: u8 = 3;
         const COPY_ZERO_SIZE: usize = 0x10000;
 
-        let mut stream = Cursor::new(&delta_obj.data_decompress);
+        let mut stream = Cursor::new(&delta_obj.data_decompressed);
 
         // Read the base object size
         // (Size Encoding)
         let (base_size, result_size) = utils::read_delta_object_size(&mut stream).unwrap();
 
         //Get the base object row data
-        let base_info = &base_obj.data_decompress;
+        let base_info = &base_obj.data_decompressed;
         assert_eq!(base_info.len(), base_size, "Base object size mismatch");
 
         let mut result = Vec::with_capacity(result_size);
@@ -602,8 +602,8 @@ impl Pack {
         // create new obj from `delta_obj` & `result` instead of modifying `delta_obj` for heap-size recording
         CacheObject {
             info: CachedObjectInfo::BaseObject(base_obj.object_type(), hash),
-            data_decompress: result,
             offset: delta_obj.offset,
+            data_decompressed: result,
             mem_recorder: None,
         } // Canonical form (Complete Object)
         // mem_size recorder will be set later outside, to keep this func param clear

--- a/mercury/src/internal/pack/decode.rs
+++ b/mercury/src/internal/pack/decode.rs
@@ -738,7 +738,7 @@ mod tests {
         let stream = ReaderStream::new(f).map_err(|e| {
             axum::Error::new(e)
         });
-        let p = Pack::new(Some(20), Some(1024*1024*1024*4), Some(tmp.clone()), true);
+        let p = Pack::new(Some(20), None, Some(tmp.clone()), true);
 
         let (tx, rx) = std::sync::mpsc::channel();
         let (pack, _ ) = p.decode_stream(stream, 1024 * 1024 * 1024, tx).await;

--- a/scorpio/src/manager/store.rs
+++ b/scorpio/src/manager/store.rs
@@ -67,7 +67,7 @@ mod test{
     fn init_test_d(){
         let db = sled::open("path.db").unwrap();
         let t = Tree::from_tree_items(vec![
-            TreeItem::new(TreeItemMode::Blob, SHA1::new(&vec![4u8,4u8,4u8,64u8,84u8,84u8]), String::from("test") )
+            TreeItem::new(TreeItemMode::Blob, SHA1::new(&[4u8,4u8,4u8,64u8,84u8,84u8]), String::from("test") )
         ]).unwrap();
             
         if let Some(encoded_value) = db.get(t.id.as_ref()).unwrap() {


### PR DESCRIPTION
… and memory efficiency

1. No `CachedObject` utilized all their fields, so we'd better fold some with a tagged union. It looks better on my machine. As for "memory efficiency", no real world impact though.
2. `generate_temp_path()` is called many times with same arguments in `get_fallback()`, could be reduced to one.
3. `SHA1::new()` now accepts `&[u8]` instead of `&Vec<u8>`, providing more flexibility.