### PR TITLE
[libra] 为 libra init 命令实现 [directory] 参数

### DIFF
--- a/aria/contents/docs/libra/command/init/index.mdx
+++ b/aria/contents/docs/libra/command/init/index.mdx
@@ -26,3 +26,5 @@ which sets up the repository without a working directory, containing only Libra 
     **Note**：Unlike Git's `--bare`, the Libra init `--bare` initializes a bare repository 
     that contains Libra's own SQLite database.  
 -   `-h`, `--help` Print help
+-   `[directory]`
+    Initialize the repository with specified directory

--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -71,7 +71,7 @@ pub async fn execute(args: CloneArgs) {
 
     // CAUTION: change [current_dir] to the repo directory
     env::set_current_dir(&local_path).unwrap();
-    let init_args = command::init::InitArgs { bare: false, directory: local_path.to_str().unwrap().to_owned() };    
+    let init_args = command::init::InitArgs { bare: false, repo_directory: local_path.to_str().unwrap().to_owned() };    
     command::init::execute(init_args).await;
     
     /* fetch remote */

--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -71,7 +71,7 @@ pub async fn execute(args: CloneArgs) {
 
     // CAUTION: change [current_dir] to the repo directory
     env::set_current_dir(&local_path).unwrap();
-    let init_args = command::init::InitArgs { bare: false };    
+    let init_args = command::init::InitArgs { bare: false, directory: local_path.to_str().unwrap().to_owned() };    
     command::init::execute(init_args).await;
     
     /* fetch remote */

--- a/libra/src/command/init.rs
+++ b/libra/src/command/init.rs
@@ -18,8 +18,9 @@ pub struct InitArgs {
     #[clap(short, long, required = false)]
     pub bare: bool,  // Default is false
 
+    /// Create a repository in the specified directory
     #[clap(default_value = ".")]
-    pub directory: String,
+    pub repo_directory: String,
 }
 
 /// Execute the init function
@@ -75,7 +76,7 @@ fn is_writable(cur_dir: &Path) -> io::Result<()> {
 pub async fn init(args: InitArgs) -> io::Result<()> {
     // Get the current directory
     // let cur_dir = env::current_dir()?;
-    let cur_dir = Path::new(&args.directory).to_path_buf();
+    let cur_dir = Path::new(&args.repo_directory).to_path_buf();
     // Join the current directory with the root directory
     let root_dir = if args.bare{
         cur_dir.clone()
@@ -89,8 +90,7 @@ pub async fn init(args: InitArgs) -> io::Result<()> {
         
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
-            "Initialization failed: The repository is already initialized at the specified location. 
-            If you wish to reinitialize, please remove the existing directory or file.",
+            "Initialization failed: The repository is already initialized at the specified location. If you wish to reinitialize, please remove the existing directory or file.",
         ));
            
     }
@@ -241,7 +241,7 @@ mod tests {
         // Set up the test environment without a Libra repository
         test::setup_clean_testing_env();
         let cur_dir = env::current_dir().unwrap();
-        let args = InitArgs {bare: false, directory: cur_dir.to_str().unwrap().to_owned() };
+        let args = InitArgs {bare: false, repo_directory: cur_dir.to_str().unwrap().to_owned() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -260,7 +260,7 @@ mod tests {
         test::setup_clean_testing_env();
         // Run the init function with --bare flag
         let cur_dir = env::current_dir().unwrap();
-        let args = InitArgs {bare: true, directory: cur_dir.to_str().unwrap().to_owned() };
+        let args = InitArgs {bare: true, repo_directory: cur_dir.to_str().unwrap().to_owned() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -276,12 +276,12 @@ mod tests {
 
         // Initialize a bare repository
         let cur_dir = env::current_dir().unwrap();
-        let init_args = InitArgs { bare: false, directory: cur_dir.to_str().unwrap().to_owned() };
+        let init_args = InitArgs { bare: false, repo_directory: cur_dir.to_str().unwrap().to_owned() };
         init(init_args).await.unwrap(); // Execute init for bare repository
     
         // Simulate trying to reinitialize the bare repo
         let result = async {
-            let args = InitArgs { bare: true, directory: cur_dir.to_str().unwrap().to_owned() };
+            let args = InitArgs { bare: true, repo_directory: cur_dir.to_str().unwrap().to_owned() };
             init(args).await
         };
 
@@ -301,7 +301,7 @@ mod tests {
         let cur_dir = env::current_dir().unwrap();
         let test_dir = cur_dir.join("test");
 
-        let args = InitArgs {bare: false, directory: test_dir.to_str().unwrap().to_owned() };
+        let args = InitArgs {bare: false, repo_directory: test_dir.to_str().unwrap().to_owned() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -326,7 +326,7 @@ mod tests {
         // Create a file with the same name as the test directory
         fs::File::create(&test_dir).unwrap();
 
-        let args = InitArgs {bare: false, directory: test_dir.to_str().unwrap().to_owned() };
+        let args = InitArgs {bare: false, repo_directory: test_dir.to_str().unwrap().to_owned() };
         // Run the init function
         let result = init(args).await;
 
@@ -349,7 +349,7 @@ mod tests {
         fs::create_dir(&test_dir).unwrap();
         fs::set_permissions(&test_dir, fs::Permissions::from_mode(0o444)).unwrap();
 
-        let args = InitArgs {bare: false, directory: test_dir.to_str().unwrap().to_owned() };
+        let args = InitArgs {bare: false, repo_directory: test_dir.to_str().unwrap().to_owned() };
         // Run the init function
         let result = init(args).await;
 

--- a/libra/src/utils/test.rs
+++ b/libra/src/utils/test.rs
@@ -107,7 +107,7 @@ pub fn setup_clean_testing_env() {
 pub async fn setup_with_new_libra() {
     setup_clean_testing_env();
     let cur_path = util::cur_dir();
-    let args = command::init::InitArgs { bare: false, directory: cur_path.to_str().unwrap().to_owned() };
+    let args = command::init::InitArgs { bare: false, repo_directory: cur_path.to_str().unwrap().to_owned() };
     command::init::init(args).await.unwrap();
 }
 

--- a/libra/src/utils/test.rs
+++ b/libra/src/utils/test.rs
@@ -106,7 +106,8 @@ pub fn setup_clean_testing_env() {
 /// switch to test dir and create a new .libra
 pub async fn setup_with_new_libra() {
     setup_clean_testing_env();
-    let args = command::init::InitArgs { bare: false };
+    let cur_path = util::cur_dir();
+    let args = command::init::InitArgs { bare: false, directory: cur_path.to_str().unwrap().to_owned() };
     command::init::init(args).await.unwrap();
 }
 


### PR DESCRIPTION
[标题] 为 libra init 命令实现 [directory] 参数

[任务简述]
Mega 项目是使用 Rust 编程语言开发的兼容 Git 的 Monorepo 引擎，其中的 libra 模块实现了 Git 客户端的部分功能，目前尚未支持所有 Git 子命令及参数。本任务将为 libra init 命令添加 [directory] 参数，以支持用户自定义仓库的创建目录。

[实现方案]
1.参考libra其他子命令的方式，在 InitArgs 结构体中添加 directory 参数，通过 Parse 库解析命令行参数
2.读取参数后，创建对应的 PathBuf，先判断该路径是否可以正常写入，不可写时返回对应的错误，可写时在目标路径创建仓库
3.在 libra init -h 命令中添加 [directory] 参数的帮助信息
4.为修改后的代码编写单元测试并运行通过