### PR TITLE
[libra] 为 libra init 命令实现 [directory] 参数

### DIFF
--- a/aria/contents/docs/libra/command/init/index.mdx
+++ b/aria/contents/docs/libra/command/init/index.mdx
@@ -28,3 +28,5 @@ which sets up the repository without a working directory, containing only Libra 
 -   `-b`, `--initial-branch <INITIAL_BRANCH>`
     Override the name of the initial branch
 -   `-h`, `--help` Print help
+-   `[directory]`
+    Initialize the repository with specified directory

--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -71,7 +71,7 @@ pub async fn execute(args: CloneArgs) {
 
     // CAUTION: change [current_dir] to the repo directory
     env::set_current_dir(&local_path).unwrap();
-    let init_args = command::init::InitArgs { bare: false, initial_branch: None };    
+    let init_args = command::init::InitArgs { bare: false, initial_branch: None, repo_directory: local_path.to_str().unwrap().to_string() };    
     command::init::execute(init_args).await;
     
     /* fetch remote */

--- a/libra/src/command/init.rs
+++ b/libra/src/command/init.rs
@@ -2,7 +2,7 @@
 //!
 //!
 //!
-use std::{env, fs, io};
+use std::{fs, io::{self, ErrorKind}, path::Path};
 
 use sea_orm::{ActiveModelTrait, DbConn, DbErr, Set, TransactionTrait};
 
@@ -11,7 +11,6 @@ use clap::Parser;
 use crate::internal::db;
 use crate::internal::model::{config, reference};
 use crate::utils::util::{DATABASE, ROOT_DIR};
-use std::path::Path;
 use crate::command::branch;
 
 #[derive(Parser, Debug)]
@@ -23,6 +22,10 @@ pub struct InitArgs {
     /// Set the initial branch name
     #[clap(short = 'b', long, required = false)]
     pub initial_branch: Option<String>,
+
+    /// Create a repository in the specified directory
+    #[clap(default_value = ".")]
+    pub repo_directory: String,
 }
 
 /// Execute the init function
@@ -44,13 +47,41 @@ fn is_reinit(cur_dir: &Path) -> bool {
     head_path.exists() || bare_head_path.exists()
 }
 
+/// Check if the target directory is writable
+fn is_writable(cur_dir: &Path) -> io::Result<()> {
+    match fs::metadata(cur_dir) {
+        Ok(metadata) => {
+            // Check if the target directory is a directory
+            if !metadata.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "The target directory is not a directory.",
+                ));
+            }
+            // Check permissions
+            if metadata.permissions().readonly() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "The target directory is read-only.",
+                ));
+            }
+        }
+        Err(e) if e.kind() != ErrorKind::NotFound => {
+            return Err(e);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 /// Initialize a new Libra repository
 /// This function creates the necessary directories and files for a new Libra repository.
 /// It also sets up the database and the initial configuration.
 #[allow(dead_code)]
 pub async fn init(args: InitArgs) -> io::Result<()> {
     // Get the current directory
-    let cur_dir = env::current_dir()?;
+    // let cur_dir = env::current_dir()?;
+    let cur_dir = Path::new(&args.repo_directory).to_path_buf();
     // Join the current directory with the root directory
     let root_dir = if args.bare{
         cur_dir.clone()
@@ -76,6 +107,14 @@ pub async fn init(args: InitArgs) -> io::Result<()> {
                 io::ErrorKind::InvalidInput,
                 format!("invalid branch name: '{}'.\n\nBranch names must:\n- Not contain spaces, control characters, or any of these characters: \\ : \" ? * [\n- Not start or end with a slash ('/'), or end with a dot ('.')\n- Not contain consecutive slashes ('//') or dots ('..')\n- Not be reserved names like 'HEAD' or contain '@{{'\n- Not be empty or just a dot ('.')\n\nPlease choose a valid branch name.", branch_name),
             ));
+        }
+    }
+
+    // Check if the target directory is writable
+    match is_writable(&cur_dir) {
+        Ok(_) => {}
+        Err(e) => {
+            return Err(e);
         }
     }
 
@@ -188,6 +227,7 @@ mod tests {
     use super::*;
     use crate::utils::test;
     use crate::internal::head::Head;
+    use std::{env, os::unix::fs::PermissionsExt};
 
     pub fn verify_init(base_dir: &Path){
 
@@ -217,7 +257,8 @@ mod tests {
     async fn test_init() {
         // Set up the test environment without a Libra repository
         test::setup_clean_testing_env();
-        let args = InitArgs { bare: false, initial_branch: None };
+        let cur_dir = env::current_dir().unwrap();
+        let args = InitArgs { bare: false, initial_branch: None, repo_directory: cur_dir.to_str().unwrap().to_string() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -229,13 +270,14 @@ mod tests {
         verify_init(libra_dir);
     }
 
-    //Test the init function with the --bare flag       
+    /// Test the init function with the --bare flag       
     #[tokio::test]
     async fn test_init_bare() {
         // Set up the test environment without a Libra repository
         test::setup_clean_testing_env();
         // Run the init function with --bare flag
-        let args = InitArgs { bare: true, initial_branch: None };
+        let cur_dir = env::current_dir().unwrap();
+        let args = InitArgs { bare: true, initial_branch: None, repo_directory: cur_dir.to_str().unwrap().to_string() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -243,19 +285,20 @@ mod tests {
         // Verify the contents of the other directory
         verify_init(libra_dir);
     }
-    //Test the init function with the --bare flag and an existing repository    
+    /// Test the init function with the --bare flag and an existing repository    
     #[tokio::test]
     async fn test_init_bare_with_existing_repo() {
         // Set up the test environment for a bare repository
         test::setup_clean_testing_env();
 
         // Initialize a bare repository
-        let init_args = InitArgs { bare: false, initial_branch: None };
+        let cur_dir = env::current_dir().unwrap();
+        let init_args = InitArgs { bare: false, initial_branch: None, repo_directory: cur_dir.to_str().unwrap().to_string() };
         init(init_args).await.unwrap(); // Execute init for bare repository
     
         // Simulate trying to reinitialize the bare repo
         let result = async {
-        let args = InitArgs { bare: true, initial_branch: None };
+        let args = InitArgs { bare: true, initial_branch: None, repo_directory: cur_dir.to_str().unwrap().to_string() };
             init(args).await
         };
 
@@ -270,7 +313,8 @@ mod tests {
     async fn test_init_with_initial_branch() {
         // Set up the test environment without a Libra repository
         test::setup_clean_testing_env();
-        let args = InitArgs { bare: false, initial_branch: Some("main".to_string()) };
+        let cur_dir = env::current_dir().unwrap();
+        let args = InitArgs { bare: false, initial_branch: Some("main".to_string()), repo_directory: cur_dir.to_str().unwrap().to_string() };
         // Run the init function
         init(args).await.unwrap();
 
@@ -316,13 +360,82 @@ mod tests {
     async fn test_invalid_branch_name(branch_name: &str) {
         // Set up the test environment without a Libra repository
         test::setup_clean_testing_env();
-        let args = InitArgs { bare: false, initial_branch: Some(branch_name.to_string()) };
+        let cur_dir = env::current_dir().unwrap(); 
+        let args = InitArgs { bare: false, initial_branch: Some(branch_name.to_string()), repo_directory: cur_dir.to_str().unwrap().to_string() };
         // Run the init function
         let result = init(args).await;
         // Check for the error
         let err = result.unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);  // Check error type
         assert!(err.to_string().contains("invalid branch name"));  // Check error message contains "invalid branch name"
+    }
+
+    /// Test the init function with [directory] parameter
+    #[tokio::test]
+    async fn test_init_with_directory() {
+        // Set up the test environment without a Libra repository
+        test::setup_clean_testing_env();
+
+        // Create a test directory
+        let cur_dir = env::current_dir().unwrap();
+        let test_dir = cur_dir.join("test");
+
+        let args = InitArgs { bare: false, initial_branch: None, repo_directory: test_dir.to_str().unwrap().to_owned() };
+        // Run the init function
+        init(args).await.unwrap();
+
+        // Verify that the `.libra` directory exists
+        let libra_dir = test_dir.join(".libra");
+        assert!(libra_dir.exists(), ".libra directory does not exist");
+
+        // Verify the contents of the other directory
+        verify_init(&libra_dir);
+    }
+
+    /// Test the init function with invalid [directory] parameter
+    #[tokio::test]
+    async fn test_init_with_invalid_directory() {
+        // Set up the test environment without a Libra repository
+        test::setup_clean_testing_env();
+
+        // Create a test file instead of a directory
+        let cur_dir = env::current_dir().unwrap();
+        let test_dir = cur_dir.join("test.txt");
+
+        // Create a file with the same name as the test directory
+        fs::File::create(&test_dir).unwrap();
+
+        let args = InitArgs { bare: false, initial_branch: None, repo_directory: test_dir.to_str().unwrap().to_owned() };
+        // Run the init function
+        let result = init(args).await;
+
+        // Check for the error
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);  // Check error type
+        assert!(err.to_string().contains("The target directory is not a directory"));  // Check error message
+    }
+
+    #[tokio::test]
+    async fn test_init_with_unauthorized_directory() {
+        // Set up the test environment without a Libra repository
+        test::setup_clean_testing_env();
+
+        // Create a test directory
+        let cur_dir = env::current_dir().unwrap();
+        let test_dir = cur_dir.join("test");
+
+        // Create a directory with restricted permissions
+        fs::create_dir(&test_dir).unwrap();
+        fs::set_permissions(&test_dir, fs::Permissions::from_mode(0o444)).unwrap();
+
+        let args = InitArgs { bare: false, initial_branch: None, repo_directory: test_dir.to_str().unwrap().to_owned() };
+        // Run the init function
+        let result = init(args).await;
+
+        // Check for the error
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);  // Check error type
+        assert!(err.to_string().contains("The target directory is read-only"));  // Check error message
     }
 
 }

--- a/libra/src/utils/test.rs
+++ b/libra/src/utils/test.rs
@@ -106,7 +106,7 @@ pub fn setup_clean_testing_env() {
 /// switch to test dir and create a new .libra
 pub async fn setup_with_new_libra() {
     setup_clean_testing_env();
-    let args = command::init::InitArgs { bare: false, initial_branch: None };
+    let args = command::init::InitArgs { bare: false, initial_branch: None, repo_directory: util::cur_dir().to_str().unwrap().to_string() };
     command::init::init(args).await.unwrap();
 }
 


### PR DESCRIPTION
[标题] 为 libra init 命令实现 [directory] 参数

[任务简述]
Mega 项目是使用 Rust 编程语言开发的兼容 Git 的 Monorepo 引擎，其中的 libra 模块实现了 Git 客户端的部分功能，目前尚未支持所有 Git 子命令及参数。本任务将为 libra init 命令添加 [directory] 参数，以支持用户自定义仓库的创建目录。

[实现方案]
1.参考libra其他子命令的方式，在 InitArgs 结构体中添加 directory 参数，通过 Parse 库解析命令行参数
2.读取参数后，创建对应的 PathBuf，先判断该路径是否可以正常写入，不可写时返回对应的错误，可写时在目标路径创建仓库
3.在 libra init -h 命令中添加 [directory] 参数的帮助信息
4.为修改后的代码编写单元测试并运行通过