### PR TITLE
Move monobean out of workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ members = [
     "taurus",
     "atlas",
     "orion",
-    "monobean"
 ]
-default-members = ["mega", "mono", "libra", "aries", "monobean"]
+default-members = ["mega", "mono", "libra", "aries"]
 resolver = "1"
 
 [workspace.dependencies]
@@ -33,7 +32,6 @@ taurus = { path = "taurus" }
 mega = { path = "mega" }
 mono = { path = "mono" }
 libra = { path = "libra" }
-monobean = { path = "monobean" }
 
 anyhow = "1.0.93"
 serde = "1.0.215"

--- a/monobean/Cargo.toml
+++ b/monobean/Cargo.toml
@@ -13,10 +13,10 @@ path = "src/main.rs"
 gtk = { version = "~0.9", package = "gtk4", features = ["v4_14"] }
 adw = { version = "~0.7", package = "libadwaita", features = ["v1_5"] }
 
-# mega.workspace = true
-# common.workspace = true
-# jupiter.workspace = true
-# gateway.workspace = true
+# mega = { path = "../mega"}
+# common ={ path = "../common"}
+# jupiter = { path = "../jupiter"}
+# gateway = { path = "../gateway"}
 
 async-channel = "2.3.1"
 

--- a/monobean/Cargo.toml
+++ b/monobean/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 license = "MIT"
 authors = ["Neon<neonkk@qq.com>"]
 
+[workspace]
+
 [[bin]]
 name = "monobean"
 path = "src/main.rs"

--- a/monobean/README.md
+++ b/monobean/README.md
@@ -41,6 +41,7 @@ Download precompiled Gtk4 libraries from [gvsbuild](https://github.com/wingtk/gv
 ```powershell
 $env:Path = "C:\gtk\bin;" + $env:Path
 $env:LIB = "C:\gtk\lib;" + $env:LIB
+$env:PKG_CONFIG_PATH = "C:\gtk\lib\pkgconfig" + $env:PKG_CONFIG_PATH
 $env:INCLUDE = "C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include;" + $env:INCLUDE
 ```
 Then build the package:

--- a/monobean/setup.py
+++ b/monobean/setup.py
@@ -49,18 +49,20 @@ def setup_environmental_variables():
     env_vars_set = {
         "Path": "resources/lib/bin;",
         "LIB": "resources/lib/lib;",
-        "INCLUDE": "resources/lib/include;resources/lib/include/cairo;resources/lib/include/glib-2.0;resources/lib/include/gobject-introspection-1.0;resources/lib/lib/glib-2.0/include;",
         "PKG_CONFIG_PATH": "resources/lib/lib/pkgconfig;"
+        "INCLUDE": "resources/lib/include;resources/lib/include/cairo;resources/lib/include/glib-2.0;resources/lib/include/gobject-introspection-1.0;resources/lib/lib/glib-2.0/include;",
     }
 
+    commands = []
     for key, value in env_vars_set.items():
         # convert to abs path
-        value = os.pathsep.join([os.path.abspath(p) for p in value.split(';')])
+        value = os.pathsep.join([os.path.abspath(p) for p in value.split(';')[:-1]])
 
-        if key in os.environ:
-            os.environ[key] = f"{value}{os.pathsep}{os.environ[key]}"
-        else:
-            os.environ[key] = value
+        commands.append(f'$env:{key} = "$env:{key};{value}"')
+
+    print("Copy and paste these commands to set environment variables in PowerShell:\n")
+    for cmd in commands:
+        print(cmd)
 
 
 if __name__ == "__main__":
@@ -101,6 +103,5 @@ if __name__ == "__main__":
 
     except Exception as e:
         print(f"Error: {e}")
-
 
     os.chdir(cwd)

--- a/monobean/setup.py
+++ b/monobean/setup.py
@@ -42,7 +42,7 @@ def download_file_with_resume(url, save_path):
         print(f"Failed to download: {e}")
 
 def setup_environmental_variables():
-    if "resources\\lib\\bin" in os.environ["Path"]:
+    if os.path.abspath("resources/lib/bin") in os.environ["Path"].split(os.pathsep):
         print("Environment variables already set!")
         return
 

--- a/monobean/src/mega.rs
+++ b/monobean/src/mega.rs
@@ -1,3 +1,6 @@
+
+
+
 #[derive(Default)]
 pub struct MegaCore {
     // config: PathBuf,


### PR DESCRIPTION
This pull request includes several changes to the `Cargo.toml` and `monobean` project files to clean up dependencies and improve setup processes. The most important changes are the removal of the `monobean` dependency from the workspace, updates to the `monobean` project configuration, and enhancements to the environment setup script.

Dependency cleanup:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R18): Removed `monobean` from the `members` and `default-members` lists, and deleted its dependency entry. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R18) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L36)

Project configuration updates:

* [`monobean/Cargo.toml`](diffhunk://#diff-c6c2e389c4bbd871c4c68f1ab86cb823ec4ef3f5021776b45e03ae1c5addd19fR8-R9): Added `[workspace]` section and updated paths for `mega`, `common`, `jupiter`, and `gateway` dependencies. [[1]](diffhunk://#diff-c6c2e389c4bbd871c4c68f1ab86cb823ec4ef3f5021776b45e03ae1c5addd19fR8-R9) [[2]](diffhunk://#diff-c6c2e389c4bbd871c4c68f1ab86cb823ec4ef3f5021776b45e03ae1c5addd19fL16-R21)

Environment setup improvements:

* [`monobean/README.md`](diffhunk://#diff-ac269f7423f7af67b0fd4cda72c7da31e8979866dda180309033a9429b562961R44): Added `PKG_CONFIG_PATH` to the environment variables setup instructions.
* [`monobean/setup.py`](diffhunk://#diff-b46bcd7f9e2ba39e20acdbb887730f13c0b0f06088ad2d14bce2267810c6f298L45-R65): Modified the `setup_environmental_variables` function to check for absolute paths and generate PowerShell commands for setting environment variables. [[1]](diffhunk://#diff-b46bcd7f9e2ba39e20acdbb887730f13c0b0f06088ad2d14bce2267810c6f298L45-R65) [[2]](diffhunk://#diff-b46bcd7f9e2ba39e20acdbb887730f13c0b0f06088ad2d14bce2267810c6f298L105)