### PR TITLE
Change global allocator for mega and mono.

### DIFF
--- a/mega/Cargo.toml
+++ b/mega/Cargo.toml
@@ -39,6 +39,12 @@ config = { workspace = true }
 shadow-rs = { workspace = true }
 ctrlc = { workspace = true }
 
+[target.'cfg(not(windows))'.dependencies]
+jemallocator = "0.5.4"
+
+[target.'cfg(windows)'.dependencies]
+mimalloc = "0.1.43"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 serial_test = "3.1.1"

--- a/mega/src/main.rs
+++ b/mega/src/main.rs
@@ -9,11 +9,11 @@ mod commands;
 
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL_ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
     // Parse the command line arguments

--- a/mega/src/main.rs
+++ b/mega/src/main.rs
@@ -7,6 +7,14 @@ shadow!(build);
 mod cli;
 mod commands;
 
+#[cfg(not(target_os = "windows"))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // Parse the command line arguments
     let result = cli::parse(None);

--- a/mercury/Cargo.toml
+++ b/mercury/Cargo.toml
@@ -37,9 +37,6 @@ memchr = { workspace = true }
 encoding_rs = { workspace = true }
 rayon = "1.10.0"
 
-[target.'cfg(windows)'.dependencies] # only on Windows
-mimalloc = "0.1.39" # avoid sticking on dropping on Windows
-
 [dev-dependencies]
 tracing-test = "0.2.4"
 tokio = { workspace = true, features = ["full"] }

--- a/mercury/README.md
+++ b/mercury/README.md
@@ -1,1 +1,36 @@
 ## Mercury Module - Git Internal Module
+
+### Performance
+
+> [!TIP]
+> Here are some performance tips that you can use to significantly improve performance when using `Mercury` crates as a dependency.
+
+In certain versions of Rust, using `HashMap` on Windows can lead to performance issues. This is due to the allocation strategy of the internal heap memory allocator. To mitigate these performance issues on Windows, you can use [mimalloc](https://github.com/microsoft/mimalloc). (See [this issue](https://github.com/rust-lang/rust/issues/121747) for more details.)
+
+On other platforms, you can also experiment with [jemalloc](https://github.com/jemalloc/jemalloc) or [mimalloc](https://github.com/microsoft/mimalloc) to potentially improve performance.
+
+A simple approach:
+
+1. Change Cargo.toml to use mimalloc on Windows and jemalloc on other platforms.
+
+   ```toml
+   [target.'cfg(not(windows))'.dependencies]
+   jemallocator = "0.5.4"
+   
+   [target.'cfg(windows)'.dependencies]
+   mimalloc = "0.1.43"
+   ```
+
+2. Add `#[global_allocator]` to the main.rs file of the program to specify the allocator.
+
+   ```rust
+   #[cfg(not(target_os = "windows"))]
+   #[global_allocator]
+   static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+   
+   #[cfg(target_os = "windows")]
+   #[global_allocator]
+   static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+   ```
+
+   

--- a/mercury/src/lib.rs
+++ b/mercury/src/lib.rs
@@ -1,14 +1,5 @@
 //! Mercury is a library for encoding and decoding Git Pack format files or streams.
 
-// to avoid sticking on Dropping large HashMap on Windows
-// but, mimalloc won't release memory to OS after dropping (TODO)
-// see [issue](https://github.com/rust-lang/rust/issues/121747)
-#[cfg(target_os = "windows")]
-use mimalloc::MiMalloc;
-#[cfg(target_os = "windows")]
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 pub mod internal;
 pub mod hash;
 pub mod errors;

--- a/mono/Cargo.toml
+++ b/mono/Cargo.toml
@@ -56,7 +56,12 @@ base64 = { workspace = true }
 async-session = "3.0.0"
 http = "1.1.0"
 cedar-policy = { workspace = true }
+
+[target.'cfg(not(windows))'.dependencies]
 jemallocator = "0.5.4"
+
+[target.'cfg(windows)'.dependencies]
+mimalloc = "0.1.43"
 
 [dev-dependencies]
 

--- a/mono/src/main.rs
+++ b/mono/src/main.rs
@@ -13,8 +13,13 @@ pub mod api;
 pub mod git_protocol;
 pub mod server;
 
+#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
     // Parse the command line arguments

--- a/mono/src/main.rs
+++ b/mono/src/main.rs
@@ -15,11 +15,11 @@ pub mod server;
 
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL_ALLOCATOR: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
     // Parse the command line arguments


### PR DESCRIPTION
link: https://github.com/web3infra-foundation/mega/issues/839

1. Remove `mimalloc` dependency in `mercury` crates and add instructions to README.md.
2. Added code to use `jemalloc` and `mimalloc` as global allocators in `mega` and `mono`.