### PR TITLE
mark `libc::major`  and `libc::minor` safe

### DIFF
--- a/scorpio/src/overlayfs/layer.rs
+++ b/scorpio/src/overlayfs/layer.rs
@@ -193,7 +193,7 @@ pub(crate) fn is_chardev(st: &FileAttr) -> bool {
 pub(crate) fn is_whiteout(st: &FileAttr) -> bool {
     // A whiteout is created as a character device with 0/0 device number.
     // See ref: https://docs.kernel.org/filesystems/overlayfs.html#whiteouts-and-opaque-directories
-    let major = unsafe { libc::major(st.rdev.into()) };
-    let minor = unsafe { libc::minor(st.rdev.into()) };
+    let major = libc::major(st.rdev.into()) ;
+    let minor = libc::minor(st.rdev.into());
     is_chardev(st) && major == 0 && minor == 0
 }


### PR DESCRIPTION
fix fuse lint failed.