### PR TITLE
p2p enable get_repos function

### DIFF
--- a/gemini/src/lib.rs
+++ b/gemini/src/lib.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-
-use callisto::{git_repo, lfs_objects, lfs_split_relations, relay_lfs_info, relay_repo_info};
+use callisto::{
+    git_repo, lfs_objects, lfs_split_relations, relay_lfs_info, relay_node, relay_repo_info,
+};
 use common::utils::generate_id;
 use serde::{Deserialize, Serialize};
 use util::get_utc_timestamp;
@@ -22,33 +22,23 @@ pub struct RelayGetParams {
     pub file_hash: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RelayResultRes {
-    pub success: bool,
-}
-
-#[derive(Debug)]
-pub enum MegaType {
-    Agent,
-    Relay,
-}
-
-impl fmt::Display for MegaType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            MegaType::Agent => write!(f, "Agent"),
-            MegaType::Relay => write!(f, "Relay"),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Node {
     pub peer_id: String,
-    pub service_name: String,
     pub mega_type: String,
     pub online: bool,
     pub last_online_time: i64,
+}
+
+impl From<relay_node::Model> for Node {
+    fn from(r: relay_node::Model) -> Self {
+        Node {
+            peer_id: r.peer_id,
+            mega_type: r.r#type,
+            online: r.online,
+            last_online_time: r.last_online_time,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/gemini/src/p2p/mod.rs
+++ b/gemini/src/p2p/mod.rs
@@ -17,6 +17,7 @@ pub enum Action {
     RepoShare,
     Nostr,
     Peers,
+    Repos,
 }
 
 impl fmt::Display for Action {
@@ -42,6 +43,9 @@ impl fmt::Display for Action {
             }
             Action::Peers => {
                 write!(f, "Peers")
+            }
+            Action::Repos => {
+                write!(f, "Repos")
             }
         }
     }
@@ -100,7 +104,7 @@ mod tests {
     //     let context = Context::new(Arc::from(config)).await;
     //     let context_clone = context.clone();
     //     tokio::spawn(async move {
-    //         client::run(context_clone.clone(), "47.74.41.94:8001".to_string())
+    //         client::run(context_clone.clone(), "127.0.0.1:8001".to_string())
     //             .await
     //             .unwrap();
     //     });
@@ -207,6 +211,22 @@ mod tests {
     //     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     //     let peers = client::get_peers().await.unwrap();
     //     info!("peers: {:?}", peers);
+    // }
+    //
+    // #[tokio::test]
+    // async fn test_get_repos() {
+    //     test_with_logs();
+    //     let config = Config::new("E:\\code\\mega\\config.toml").unwrap();
+    //     let context = Context::new(Arc::from(config)).await;
+    //     let context_clone = context.clone();
+    //     tokio::spawn(async move {
+    //         client::run(context_clone.clone(), "127.0.0.1:8001".to_string())
+    //             .await
+    //             .unwrap();
+    //     });
+    //     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    //     let repos = client::get_repos().await.unwrap();
+    //     info!("repos: {:?}", repos);
     // }
     //
     // fn test_with_logs() {


### PR DESCRIPTION
p2p enable get_repos function
you can try gemini::p2p::client::get_repos 
the result will be:
```
[RepoInfo { name: "git_inner_net", identifier: "p2p://24ok5kQFeJ3wTKYM31e75LwUzZv1e3xsGG7SE9XpdAtvX/third-part/git_inner_net.git", origin: "24ok5kQFeJ3wTKYM31e75LwUzZv1e3xsGG7SE9XpdAtvX", update_time: 1744005476, commit: "4886c6b9a98afed49a734edd7c420c987d5fa471", peer_online: true }]
```