### PR TITLE
[libra] 提供 .gitignore 支持

### DIFF
--- a/aria/contents/docs/libra/config/gitignore/index.mdx
+++ b/aria/contents/docs/libra/config/gitignore/index.mdx
@@ -1,4 +1,39 @@
 ---
 title: The .gitignore File
-description:
+description: Specify files and directories that Libra should ignore
 ---
+
+### Introduction
+
+The `.gitignore` file, or more precisely in this project, the `.libraignore` file, is used to specify files and directories that Libra should ignore. These files and directories will not be tracked by Libra. If a file is already tracked by Libra, the `.libraignore` file will not affect it.
+
+The patterns in the `.libraignore` file determine whether a path should be ignored. These patterns can be simple filenames, wildcards, or more complex patterns.
+
+### .libraignore File Usage
+
+#### Compatibility with Gitignore Patterns
+
+The `.libraignore` file supports the same pattern syntax as `.gitignore`. This includes:
+
+- **Simple Filenames**: Directly specify a filename. For example, `file.txt` matches a file named `file.txt` in the current directory.
+- **Wildcards**: Use `*` to match any sequence of characters. For example, `*.tmp` matches all files ending with `.tmp`.
+- **Directory Matching**: Use `/` to match directories. For example, `dir/` matches a directory named `dir`.
+- **Recursive Matching**: Use `**` to match any path. For example, `**/*.tmp` matches all files ending with `.tmp` in any directory.
+- **Exclusion Patterns**: Use `!` at the beginning of a pattern to exclude files that were previously matched. For example, `!file.txt` excludes `file.txt` from being ignored.
+- **Comments**: Lines starting with `#` are treated as comments and are not parsed.
+
+#### Matching Rules
+
+Libra checks for `.libraignore` files from the directory of the target file upwards to the root of the working directory. If a match is found in any `.libraignore` file, the file will be ignored.
+
+- **Matching Order**: Libra starts checking from the directory of the target file and moves upwards. Once a match is found, Libra stops checking and ignores the file.
+- **Subdirectory Precedence**: If multiple `.libraignore` files contain matching patterns, the patterns in the `.libraignore` file closest to the target file take precedence.
+
+
+#### Support for .libraignore in Subdirectories
+
+Libra supports placing `.libraignore` files in any subdirectory within the working directory. Libra will check for `.libraignore` files from the directory of the target file upwards to the root of the working directory. If a match is found in any `.libraignore` file along the path, the file will be ignored.
+
+- **Subdirectory `.libraignore` Files**: The patterns in a `.libraignore` file within a subdirectory are relative to that subdirectory. For example, if there is a pattern `*.tmp` in `work_dir/subdir/.libraignore`, it will match `file.tmp` within `subdir`, but not `file.tmp` in the root of the working directory.
+
+

--- a/libra/Cargo.toml
+++ b/libra/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 gemini = { workspace = true, optional = true }
 hex = { workspace = true }
+ignore = "0.4.23"
 imara-diff = "0.1.7"
 indicatif = "0.17.8"
 infer = "0.19.0"

--- a/libra/src/command/add.rs
+++ b/libra/src/command/add.rs
@@ -30,7 +30,6 @@ pub struct AddArgs {
 }
 
 pub async fn execute(args: AddArgs) {
-    // TODO .gitignore
     if !util::check_repo_exist() {
         return;
     }

--- a/libra/src/command/diff.rs
+++ b/libra/src/command/diff.rs
@@ -255,8 +255,10 @@ async fn get_commit_blobs(commit_hash: &SHA1) -> Vec<(PathBuf, SHA1)> {
 
 // diff need to print hash even if the file is not added
 fn get_files_blobs(files: &[PathBuf]) -> Vec<(PathBuf, SHA1)> {
+    let working_dir = util::working_dir();
     files
         .iter()
+        .filter(|&p| !util::check_gitignore(&working_dir, p))
         .map(|p| {
             let path = util::workdir_to_absolute(p);
             let data = std::fs::read(&path).unwrap();

--- a/libra/src/command/status.rs
+++ b/libra/src/command/status.rs
@@ -45,7 +45,6 @@ pub async fn execute() {
     if !util::check_repo_exist() {
         return;
     }
-    // TODO .gitignore
     match Head::current().await {
         Head::Detached(commit) => {
             println!(
@@ -167,7 +166,9 @@ pub fn changes_to_be_staged() -> Changes {
     for file in tracked_files.iter() {
         let file_str = file.to_str().unwrap();
         let file_abs = util::workdir_to_absolute(file);
-        if !file_abs.exists() {
+        if util::check_gitignore(&workdir, &file_abs) {
+            continue;
+        } else if !file_abs.exists() {
             changes.deleted.push(file.clone());
         } else if index.is_modified(file_str, 0, &workdir) {
             // only calc the hash if the file is modified (metadata), for optimization

--- a/libra/src/utils/lfs.rs
+++ b/libra/src/utils/lfs.rs
@@ -43,7 +43,7 @@ where
 
     let mut gitignore = GitignoreBuilder::new(util::working_dir());
     patterns.iter().for_each(|&s| {
-        gitignore.add_line(None, s).unwrap();
+        let _ = gitignore.add_line(None, s);
     });
     let gitignore = gitignore.build().unwrap();
     let match_gitignore = gitignore.matched(&path, false);

--- a/libra/src/utils/lfs.rs
+++ b/libra/src/utils/lfs.rs
@@ -1,5 +1,6 @@
 use crate::utils::path_ext::PathExt;
 use crate::utils::{path, util};
+use ignore::{gitignore::GitignoreBuilder, Match};
 use lazy_static::lazy_static;
 use mercury::internal::index::Index;
 use regex::Regex;
@@ -11,7 +12,6 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 use url::Url;
 use wax::Pattern;
-use ignore::{gitignore::GitignoreBuilder, Match};
 
 lazy_static! {
     static ref LFS_PATTERNS: Vec<String> = { // cache
@@ -28,7 +28,7 @@ lazy_static! {
 }
 
 /// Check if a file is LFS tracked
-/// - support Glob pattern matching (TODO: support .gitignore patterns)
+/// - support Glob pattern matching
 /// - only check root attributes file now, should check all attributes files in sub-dirs
 /// - absolute path
 pub fn is_lfs_tracked<P>(path: P) -> bool
@@ -47,10 +47,7 @@ where
     });
     let gitignore = gitignore.build().unwrap();
     let match_gitignore = gitignore.matched(&path, false);
-    let gitignore_matched = match match_gitignore {
-        Match::Ignore(_) => false,
-        _ => true,
-    };
+    let gitignore_matched = matches!(match_gitignore, Match::Ignore(_));
 
     let path = util::to_workdir_path(path);
     let glob = wax::any(patterns).unwrap();

--- a/libra/src/utils/util.rs
+++ b/libra/src/utils/util.rs
@@ -346,7 +346,7 @@ pub fn default_progress_bar(len: u64) -> ProgressBar {
 }
 
 /// Check each directory level from `work_dir` to `target_file` to see if there is a `.gitignore` file that matches `target_file`.
-/// 
+///
 /// Assume `target_file` is `in work_dir`.
 pub fn check_gitignore(work_dir: &PathBuf, target_file: &PathBuf) -> bool {
     assert!(target_file.starts_with(work_dir));
@@ -359,7 +359,10 @@ pub fn check_gitignore(work_dir: &PathBuf, target_file: &PathBuf) -> bool {
         if cur_file.exists() {
             let (ignore, err) = Gitignore::new(&cur_file);
             if let Some(e) = err {
-                println!("warniing: There are some invalid globs in libraignore file {:#?}:\n{}\n", cur_file, e);
+                println!(
+                    "warniing: There are some invalid globs in libraignore file {:#?}:\n{}\n",
+                    cur_file, e
+                );
             }
             if let Match::Ignore(_) = ignore.matched(target_file, false) {
                 return true;


### PR DESCRIPTION
此 PR 完成了 r2cn 测试任务 #941 ，为 `add`, `status`, `diff` 提供了 .gitignore 支持，并给 lfs 中添加了 gitignore 模式的匹配。

不过由于这些命令涉及文件 IO，我没有添加单元测试。如果需要添加测试，请告诉我，我会尝试添加集成测试或者重构部分代码以适合单元测试。