### PR TITLE
CI: run test on self-hosted Arch Linux

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ self-hosted, macos-latest, windows-latest ]
+        os: [ self-hosted, ubuntu-latest, macos-latest, windows-latest ]
 
     name: Setup and cache ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ self-hosted, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
     needs: setup
@@ -118,7 +118,7 @@ jobs:
   test:
     name: Test for ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ self-hosted, macos-latest, windows-latest ]
 
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ self-hosted, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
     needs: setup

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -122,9 +122,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ self-hosted, macos-latest, windows-latest ]
 
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: setup
     env:
       CARGO_TERM_COLOR: always
@@ -160,9 +160,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ self-hosted, macos-latest, windows-latest ]
 
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: setup
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -20,7 +20,6 @@ on:
       - 'scripts/**'
       - 'third-party/**'
       - 'toolchains/**'
-      - '.github/**'
   pull_request:
     paths-ignore:
       - 'alfs/**'
@@ -34,7 +33,6 @@ on:
       - 'scripts/**'
       - 'third-party/**'
       - 'toolchains/**'
-      - '.github/**'
 
 name: Base GitHub Action for Check, Test and Lints
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -48,10 +48,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ self-hosted, macos-latest, windows-latest ]
 
     name: Setup and cache ${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     env:
       CARGO_TERM_COLOR: always
@@ -92,9 +92,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ self-hosted, macos-latest, windows-latest ]
 
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: setup
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
This pull request updates the `.github/workflows/base.yml` file to improve the flexibility and reliability of the GitHub Actions workflow. The changes primarily focus on modifying the operating system matrix, adjusting the `runs-on` configuration, and ensuring consistency in job definitions.

![{A48A1CE4-1751-4889-894A-5D177BB4CE55}](https://github.com/user-attachments/assets/e068627d-72a2-48ba-820a-980fc5a99c82)

### Workflow configuration updates:

* Removed the exclusion of `.github/**` paths from the `pull_request` trigger to ensure workflow changes are properly tested when modified. [[1]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L23) [[2]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L37)

* Added `self-hosted` to the operating system matrix for jobs, allowing workflows to run on self-hosted runners in addition to GitHub-hosted runners. [[1]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L51-R52) [[2]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L123-R125)

* Simplified the `runs-on` configuration by directly using the `matrix.os` value instead of conditional logic. [[1]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L51-R52) [[2]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L97-R95) [[3]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L123-R125) [[4]](diffhunk://#diff-c4d4a4472caf54b259ef50bf892777a16a577791095ed7dc10a740fab65e2060L165-R163)

* Changed the `fail-fast` strategy for the `test` job from `true` to `false` to prevent the workflow from stopping prematurely if one matrix job fails.