### PR TITLE
Fix issues in libra status and database connection handling

### DIFF
--- a/libra/src/command/checkout.rs
+++ b/libra/src/command/checkout.rs
@@ -123,6 +123,7 @@ mod tests {
     use super::*;
     use crate::command::{commit, init};
     use colored::Colorize;
+    use serial_test::serial;
     use std::{env, fs};
     use tempfile::tempdir;
 
@@ -166,6 +167,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_checkout_module_functions() {
         println!("\n\x1b[1mTest checkout module functions.\x1b[0m");
 

--- a/libra/src/command/commit.rs
+++ b/libra/src/command/commit.rs
@@ -256,6 +256,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial]
     #[should_panic]
     async fn test_execute_commit_with_empty_index_fail() {
         test::setup_with_new_libra().await;

--- a/libra/src/command/status.rs
+++ b/libra/src/command/status.rs
@@ -46,11 +46,8 @@ pub async fn execute() {
         return;
     }
     match Head::current().await {
-        Head::Detached(commit) => {
-            println!(
-                "HEAD detached at {}",
-                String::from_utf8_lossy(&commit.0[0..7])
-            );
+        Head::Detached(commit_hash) => {
+            println!("HEAD detached at {}", &commit_hash.to_string()[..8]);
         }
         Head::Branch(branch) => {
             println!("On branch {}", branch);

--- a/libra/src/command/switch.rs
+++ b/libra/src/command/switch.rs
@@ -122,6 +122,7 @@ mod tests {
     use crate::command::add;
     use crate::command::init;
     use crate::command::restore::RestoreArgs;
+    use serial_test::serial;
     use std::str::FromStr;
     use std::{env, fs};
     use tempfile::tempdir;
@@ -165,6 +166,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_parts_of_switch_module_function() {
         println!("\n\x1b[1mTest some functions of the switch module.\x1b[0m");
 

--- a/libra/src/internal/db.rs
+++ b/libra/src/internal/db.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::path::Path;
+#[cfg(not(test))]
 use tokio::sync::OnceCell;
 
 /// Establish a connection to the database.
@@ -31,13 +32,60 @@ pub async fn establish_connection(db_path: &str) -> Result<DatabaseConnection, I
         )
     })
 }
-
+#[cfg(not(test))]
 static DB_CONN: OnceCell<DbConn> = OnceCell::const_new();
 /// Get global database connection instance (singleton)
+#[cfg(not(test))]
 pub async fn get_db_conn_instance() -> &'static DbConn {
     DB_CONN
         .get_or_init(|| async { get_db_conn().await.unwrap() })
         .await
+}
+
+#[cfg(test)]
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use std::collections::HashMap;
+//#[cfg(test)]
+//use std::ops::Deref;
+#[cfg(test)]
+use std::path::PathBuf;
+#[cfg(test)]
+use tokio::sync::Mutex;
+
+// In the test environment, use a `HashMap` to store database connections
+// mapped by their working directories.
+// change the value type from Box<DbConn> to &'static DbConn
+#[cfg(test)]
+static TEST_DB_CONNECTIONS: Lazy<Mutex<HashMap<PathBuf, &'static DbConn>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(test)]
+#[allow(dead_code)]
+fn leak_conn(conn: DbConn) -> &'static DbConn {
+    let boxed = Box::new(conn);
+    let static_ref = Box::leak(boxed);
+    static_ref
+}
+
+/// In the test environment, each working directory should have its own database connection.
+/// A global `HashMap` is used to store and manage these connections separately.
+#[cfg(test)]
+pub async fn get_db_conn_instance() -> &'static DbConn {
+    let current_dir = std::env::current_dir().unwrap();
+
+    let mut connections = TEST_DB_CONNECTIONS.lock().await;
+
+    if !connections.contains_key(&current_dir) {
+        let conn = get_db_conn().await.unwrap();
+        let boxed_conn = Box::new(conn);
+        //connections.insert(current_dir.clone(), boxed_conn);
+        connections.insert(current_dir.clone(), Box::leak(boxed_conn));
+    }
+
+    let boxed_conn = connections.get(&current_dir).unwrap();
+    boxed_conn
+    // leak_conn(boxed_conn.deref().clone())
 }
 
 /// Create a connection to the database of current repo: `.libra/libra.db`


### PR DESCRIPTION
- Fixed garbled output when libra status is in a detached HEAD state.
- Adjusted database connection management for test environments.
- 原来的libra statuc，在HEAD游离的时候会显示乱码。
- libra的单元测试失败，一个是因为有些测试并行执行造成了冲突；一个是因为数据库连接只有一个，对不同路径的测试有影响。修复是测试全部添加#[serial]；然后db.rs，测试的时候，按照工作路径保存对应的数据库连接。