### PR TITLE
fix(UI): Use admin_headers when postInvitations

### DIFF
--- a/moon/apps/web/pages/index.tsx
+++ b/moon/apps/web/pages/index.tsx
@@ -13,6 +13,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
   try {
     const { device } = userAgentFromString(req.headers['user-agent'])
     const headers = apiCookieHeaders(req.cookies)
+    //todo: Encrypted storage or server-side retrieval
+    const admin_headers = {
+      Cookie: '_campsite_api_session=sHKWgLii9No0CuFrr4q29G3iGisYILKp1776kwY%2Fb5xK24RFioyvcA9yPZDlK9ZavemJLQtjvSpuwwYE8LTyc6KF0wtaJFFYBqhx9YVRBfOXSFSRQeTi8A2X2GXe6SrEvYSTWDdPVI0et2mpvt2RwR6ajbolpRw57D9XBdLrGaQnIZ6YnUbXOmbPSDY34lyH4X%2FhX6oS1ms%2FPMtqbZh%2BAZiaXE0l2pjl9iWsvGHN1YpUv8kwcD5KcqtvBpJwaSChG7lXDkVy4SP2k9PzKmL8Zui79sDGZEJ5D8oRKo6a9uVy%2FeROaD1ewlHXylU%2FdWHcR%2Ft6Z1TrjxPWIDs6VB5nDudxFgap5XNjOvH4%2FG9t7pi%2FGfvteu%2B1yJ8%2Fkiz1jlg%2B7onVGNKJT2mmsHaJ6JF1QMAj0UgakG0a7hc8ui77v0VxE5avGc9I0i1z8mo4hX0k8yOVOPZkp5GwQHsBJK0%2BKmg%2Fsw%2BG5Fc%3D--qs0r30iu9tg2D6wn--EZ%2FzQJVCBVvWjVKG13PnLw%3D%3D',
+      'x-campsite-ssr-secret': ''
+    }
 
     const organizations = await apiClient.organizationMemberships
       .getOrganizationMemberships()
@@ -66,7 +71,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
             }
           ]
         },
-        { headers }
+        { headers: admin_headers }
       )
 
       const invitations = await apiClient.users.getMeOrganizationInvitations().request({ headers })


### PR DESCRIPTION
!!Temporary Fix #1058 
Explicitly write administrator cookies in a file, need to investigate secure methods for getting cookies.