### PR TITLE
feat(libra): 为 log 命令添加 --oneline 参数，实现单行简洁格式显示提交历史 #1227

### DIFF
--- a/aria/contents/docs/libra/command/log/index.mdx
+++ b/aria/contents/docs/libra/command/log/index.mdx
@@ -22,6 +22,8 @@ List commits that are reachable by current local branch. The order is from the l
 
 -   `-n`, `--number <NUMBER>`
     Limit the number of output
+-   `--oneline`
+    Shorthand for `--pretty=oneline --abbrev-commit`. Display each commit as a single line with abbreviated commit hash (7 characters) and commit message first line only.
 -   `-h`, `--help`
     Print help
 

--- a/libra/tests/command/mod.rs
+++ b/libra/tests/command/mod.rs
@@ -4,7 +4,7 @@ use libra::command::branch::BranchArgs;
 use libra::command::get_target_commit;
 use libra::command::init::init;
 use libra::command::init::InitArgs;
-use libra::command::log::get_reachable_commits;
+use libra::command::log::{get_reachable_commits, LogArgs};
 use libra::command::save_object;
 use libra::command::status::changes_to_be_staged;
 use libra::command::switch::{self, check_status, SwitchArgs};


### PR DESCRIPTION
此 PR 完成了 r2cn 测试任务 #1277，为 libra log 命令添加 --oneline 参数

功能描述
为 libra log 命令实现 --oneline 参数，显示简化的单行提交历史格式，兼容 git log --oneline 行为。

实现方案
在 LogArgs 结构体中添加 oneline 布尔字段，使用 clap 的 #[clap(long)] 注解
在 execute 函数中实现条件格式化逻辑：
oneline 格式：7位短哈希（黄色）+ 提交消息首行
保持原有详细格式不变
兼容现有 -n/--number 参数，可组合使用

测试覆盖
添加 test_log_oneline 测试用例
验证短哈希长度为7个字符
确保提交消息解析正确
测试与 --number 参数的组合使用

文档更新
更新 aria/contents/docs/libra/command/log/index.mdx
添加 --oneline 参数说明和功能描述

相关Issue
Closes #1227 