### PR TITLE
[libra]FIX: missing .gitignore tick in readme

### DIFF
--- a/libra/README.md
+++ b/libra/README.md
@@ -80,7 +80,7 @@ achieving unified management.
 - [x] `fetch`
 
 ### Others
-- [ ] `.gitignore`
+- [x] `.gitignore`
 - [x] `.gitattributes` (only for `lfs` now)
 - [x] `LFS` (embedded, with p2p feature)
 - [ ] `ssh`


### PR DESCRIPTION
The ignore function is already been implemented but is marked as unfinished in the readme file

closes #1256 