### PR TITLE
Fix: add migration

### DIFF
--- a/jupiter/src/migration/m20250804_151214_alter_builds_end_at.rs
+++ b/jupiter/src/migration/m20250804_151214_alter_builds_end_at.rs
@@ -1,0 +1,56 @@
+use sea_orm_migration::{prelude::*, schema::*, sea_orm::DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        match backend {
+            DatabaseBackend::Postgres => {
+                // ALTER TABLE builds ALTER COLUMN end_at DROP NOT NULL
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Builds::Table)
+                            .modify_column(timestamp_null(Builds::EndAt).to_owned())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {}
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        match backend {
+            DatabaseBackend::Postgres => {
+                // Reverting the change - making end_at NOT NULL again
+                // Note: This could fail if there are NULL values in the column
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Builds::Table)
+                            .modify_column(timestamp(Builds::EndAt).to_owned())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {}
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Builds {
+    Table,
+    EndAt,
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -45,7 +45,7 @@ mod m20250628_025312_add_username_in_conversation;
 mod m20250702_072055_add_item_assignees;
 mod m20250710_073119_create_reactions;
 mod m20250725_103004_add_note;
-
+mod m20250804_151214_alter_builds_end_at;
 /// Creates a primary key column definition with big integer type.
 ///
 /// # Arguments
@@ -78,6 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250702_072055_add_item_assignees::Migration),
             Box::new(m20250710_073119_create_reactions::Migration),
             Box::new(m20250725_103004_add_note::Migration),
+            Box::new(m20250804_151214_alter_builds_end_at::Migration),
         ]
     }
 }


### PR DESCRIPTION
对orion-server的数据库表字段修改进行迁移,将end_at字段改为允许为空
```rust
pub struct Model {
    #[sea_orm(primary_key, auto_increment = false)]
    pub build_id: Uuid,
    pub output_file: String,
    /// Exit code of the build process. None if process was terminated by signal on Unix
    pub exit_code: Option<i32>,
    pub start_at: DateTimeUtc,
    pub end_at: DateTimeUtc,//修改这个字段为Option<...>
    pub repo_name: String,
    /// Build target specification (e.g., "//:main")
    pub target: String,
    pub arguments: String,
    /// Merge request identifier
    pub mr: String,
}
```
```rust
pub struct Model {
    #[sea_orm(primary_key, auto_increment = false)]
    pub build_id: Uuid,
    pub output_file: String,
    /// Exit code of the build process. None if process was terminated by signal on Unix
    pub exit_code: Option<i32>,
    pub start_at: DateTimeUtc,
    pub end_at: Option<DateTimeUtc>,
    pub repo_name: String,
    /// Build target specification (e.g., "//:main")
    pub target: String,
    pub arguments: String,
    /// Merge request identifier
    pub mr: String,
}
```