### PR TITLE
feat: add task-outout swagger and cargo fmt some files

### DIFF
--- a/libra/tests/command/add_test.rs
+++ b/libra/tests/command/add_test.rs
@@ -68,9 +68,18 @@ async fn test_add_multiple_files() {
 
     // Verify all files were added to index
     let changes = changes_to_be_committed().await;
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_1.txt"));
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_2.txt"));
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_3.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_1.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_2.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_3.txt"));
 }
 
 #[tokio::test]
@@ -103,9 +112,18 @@ async fn test_add_all_flag() {
 
     // Verify all files were added to index
     let changes = changes_to_be_committed().await;
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_1.txt"));
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_2.txt"));
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file_3.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_1.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_2.txt"));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == "test_file_3.txt"));
 }
 
 #[tokio::test]
@@ -119,11 +137,11 @@ async fn test_add_update_flag() {
     // Create files and add one to the index
     let tracked_file = "tracked_file.txt";
     let untracked_file = "untracked_file.txt";
-    
+
     // Create and write initial content
     let mut file1 = fs::File::create(tracked_file).unwrap();
     file1.write_all(b"Initial content").unwrap();
-    
+
     let mut file2 = fs::File::create(untracked_file).unwrap();
     file2.write_all(b"Initial content").unwrap();
 
@@ -140,10 +158,18 @@ async fn test_add_update_flag() {
     .await;
 
     // Modify both files
-    let mut file1 = fs::OpenOptions::new().write(true).truncate(true).open(tracked_file).unwrap();
+    let mut file1 = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(tracked_file)
+        .unwrap();
     file1.write_all(b" - Modified").unwrap();
-    
-    let mut file2 = fs::OpenOptions::new().write(true).truncate(true).open(untracked_file).unwrap();
+
+    let mut file2 = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(untracked_file)
+        .unwrap();
     file2.write_all(b" - Modified").unwrap();
 
     // Execute add command with --update flag
@@ -161,9 +187,15 @@ async fn test_add_update_flag() {
     // Verify only tracked file was updated
     let changes = changes_to_be_staged();
     // Tracked file should not appear in changes (because it was updated in index)
-    assert!(!changes.modified.iter().any(|x| x.to_str().unwrap() == tracked_file));
+    assert!(!changes
+        .modified
+        .iter()
+        .any(|x| x.to_str().unwrap() == tracked_file));
     // Untracked file should still be untracked and show as new
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == untracked_file));
+    assert!(changes
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == untracked_file));
 }
 
 #[tokio::test]
@@ -176,12 +208,14 @@ async fn test_add_with_ignore_patterns() {
 
     // Create .libraignore file
     let mut ignore_file = fs::File::create(".libraignore").unwrap();
-    ignore_file.write_all(b"ignored_*.txt\nignore_dir/**").unwrap();
+    ignore_file
+        .write_all(b"ignored_*.txt\nignore_dir/**")
+        .unwrap();
 
     // Create files that should be ignored and not ignored
     let ignored_file = "ignored_file.txt";
     let tracked_file = "tracked_file.txt";
-    
+
     // Create directory that should be ignored
     fs::create_dir("ignore_dir").unwrap();
     let ignored_dir_file = "ignore_dir/file.txt";
@@ -189,10 +223,10 @@ async fn test_add_with_ignore_patterns() {
     // Create and write content
     let mut file1 = fs::File::create(ignored_file).unwrap();
     file1.write_all(b"Should be ignored").unwrap();
-    
+
     let mut file2 = fs::File::create(tracked_file).unwrap();
     file2.write_all(b"Should be tracked").unwrap();
-    
+
     let mut file3 = fs::File::create(ignored_dir_file).unwrap();
     file3.write_all(b"Should be ignored").unwrap();
 
@@ -211,16 +245,34 @@ async fn test_add_with_ignore_patterns() {
     // Verify only non-ignored files were added
     let changes_staged = changes_to_be_staged();
     let changes_committed = changes_to_be_committed().await;
-    
+
     // Ignored files should not appear in any status (they are ignored)
-    assert!(!changes_staged.new.iter().any(|x| x.to_str().unwrap() == ignored_file));
-    assert!(!changes_staged.new.iter().any(|x| x.to_str().unwrap() == ignored_dir_file));
-    assert!(!changes_committed.new.iter().any(|x| x.to_str().unwrap() == ignored_file));
-    assert!(!changes_committed.new.iter().any(|x| x.to_str().unwrap() == ignored_dir_file));
-    
+    assert!(!changes_staged
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == ignored_file));
+    assert!(!changes_staged
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == ignored_dir_file));
+    assert!(!changes_committed
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == ignored_file));
+    assert!(!changes_committed
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == ignored_dir_file));
+
     // Non-ignored file should not show as new in staged (was added) but should show in committed
-    assert!(!changes_staged.new.iter().any(|x| x.to_str().unwrap() == tracked_file));
-    assert!(changes_committed.new.iter().any(|x| x.to_str().unwrap() == tracked_file));
+    assert!(!changes_staged
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == tracked_file));
+    assert!(changes_committed
+        .new
+        .iter()
+        .any(|x| x.to_str().unwrap() == tracked_file));
 }
 
 #[tokio::test]

--- a/libra/tests/command/diff_test.rs
+++ b/libra/tests/command/diff_test.rs
@@ -13,7 +13,11 @@ fn create_file(path: &str, content: &str) {
 
 /// Helper function to modify a file with new content.
 fn modify_file(path: &str, content: &str) {
-    let mut file = fs::OpenOptions::new().write(true).truncate(true).open(path).unwrap();
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .unwrap();
     file.write_all(content.as_bytes()).unwrap();
 }
 
@@ -27,7 +31,7 @@ async fn test_basic_diff() {
 
     // Create a file and add it to index
     create_file("file1.txt", "Initial content\nLine 2\nLine 3\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -54,9 +58,7 @@ async fn test_basic_diff() {
     modify_file("file1.txt", "Modified content\nLine 2\nLine 3 changed\n");
 
     // Run diff command
-    let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "histogram"
-    ]);
+    let args = DiffArgs::parse_from(["diff", "--algorithm", "histogram"]);
     diff::execute(args).await;
 
     // We can't easily capture stdout, so we'll check that the command didn't panic
@@ -72,7 +74,7 @@ async fn test_diff_staged() {
 
     // Create a file and add it to index
     create_file("file1.txt", "Initial content\nLine 2\nLine 3\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -97,7 +99,7 @@ async fn test_diff_staged() {
 
     // Modify the file and stage it
     modify_file("file1.txt", "Modified content\nLine 2\nLine 3 changed\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -110,12 +112,13 @@ async fn test_diff_staged() {
     .await;
 
     // Modify the file again (so working dir differs from staged)
-    modify_file("file1.txt", "Modified content again\nLine 2\nLine 3 changed again\n");
+    modify_file(
+        "file1.txt",
+        "Modified content again\nLine 2\nLine 3 changed again\n",
+    );
 
     // Run diff command with --staged flag
-    let args = DiffArgs::parse_from([
-        "diff", "--staged", "--algorithm", "histogram"
-    ]);
+    let args = DiffArgs::parse_from(["diff", "--staged", "--algorithm", "histogram"]);
     diff::execute(args).await;
 
     // The command should complete without panicking
@@ -131,7 +134,7 @@ async fn test_diff_between_commits() {
 
     // Create a file and make initial commit
     create_file("file1.txt", "Initial content\nLine 2\nLine 3\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -158,7 +161,7 @@ async fn test_diff_between_commits() {
 
     // Modify file and create a second commit
     modify_file("file1.txt", "Modified content\nLine 2\nLine 3 changed\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -185,7 +188,13 @@ async fn test_diff_between_commits() {
 
     // Run diff command comparing the two commits
     let args = DiffArgs::parse_from([
-        "diff", "--old", &first_commit.to_string(), "--new", &second_commit.to_string(), "--algorithm", "histogram"
+        "diff",
+        "--old",
+        &first_commit.to_string(),
+        "--new",
+        &second_commit.to_string(),
+        "--algorithm",
+        "histogram",
     ]);
     diff::execute(args).await;
 
@@ -203,7 +212,7 @@ async fn test_diff_with_pathspec() {
     // Create multiple files and commit them
     create_file("file1.txt", "File 1 content\nLine 2\nLine 3\n");
     create_file("file2.txt", "File 2 content\nLine 2\nLine 3\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from(".")],
         all: false,
@@ -230,9 +239,7 @@ async fn test_diff_with_pathspec() {
     modify_file("file2.txt", "File 2 modified\nLine 2\nLine 3 changed\n");
 
     // Run diff command with specific file path
-    let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "histogram", "file1.txt"
-    ]);
+    let args = DiffArgs::parse_from(["diff", "--algorithm", "histogram", "file1.txt"]);
     diff::execute(args).await;
 
     // The command should complete without panicking
@@ -248,7 +255,7 @@ async fn test_diff_output_to_file() {
 
     // Create a file and commit it
     create_file("file1.txt", "Initial content\nLine 2\nLine 3\n");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -277,17 +284,21 @@ async fn test_diff_output_to_file() {
     let output_file = "diff_output.txt";
 
     // Run diff command with output to file
-    let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "histogram", "--output", output_file
-    ]);
+    let args = DiffArgs::parse_from(["diff", "--algorithm", "histogram", "--output", output_file]);
     diff::execute(args).await;
 
     // Verify the output file exists
-    assert!(fs::metadata(output_file).is_ok(), "Output file should exist");
-    
+    assert!(
+        fs::metadata(output_file).is_ok(),
+        "Output file should exist"
+    );
+
     // Read the file content to make sure it contains diff output
     let content = fs::read_to_string(output_file).unwrap();
-    assert!(content.contains("diff --git"), "Output should contain diff header");
+    assert!(
+        content.contains("diff --git"),
+        "Output should contain diff header"
+    );
 }
 
 #[tokio::test]
@@ -303,7 +314,7 @@ async fn test_diff_algorithms() {
         "file1.txt",
         "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\n",
     );
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("file1.txt")],
         all: false,
@@ -333,24 +344,39 @@ async fn test_diff_algorithms() {
 
     // Test histogram algorithm
     let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "histogram", "--output", "histogram_diff.txt"
+        "diff",
+        "--algorithm",
+        "histogram",
+        "--output",
+        "histogram_diff.txt",
     ]);
     diff::execute(args).await;
 
     // Test myers algorithm
-    let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "myers", "--output", "myers_diff.txt"
-    ]);
+    let args = DiffArgs::parse_from(["diff", "--algorithm", "myers", "--output", "myers_diff.txt"]);
     diff::execute(args).await;
 
     // Test myersMinimal algorithm
     let args = DiffArgs::parse_from([
-        "diff", "--algorithm", "myersMinimal", "--output", "myersMinimal_diff.txt"
+        "diff",
+        "--algorithm",
+        "myersMinimal",
+        "--output",
+        "myersMinimal_diff.txt",
     ]);
     diff::execute(args).await;
 
     // Verify all output files exist
-    assert!(fs::metadata("histogram_diff.txt").is_ok(), "Histogram output file should exist");
-    assert!(fs::metadata("myers_diff.txt").is_ok(), "Myers output file should exist");
-    assert!(fs::metadata("myersMinimal_diff.txt").is_ok(), "MyersMinimal output file should exist");
+    assert!(
+        fs::metadata("histogram_diff.txt").is_ok(),
+        "Histogram output file should exist"
+    );
+    assert!(
+        fs::metadata("myers_diff.txt").is_ok(),
+        "Myers output file should exist"
+    );
+    assert!(
+        fs::metadata("myersMinimal_diff.txt").is_ok(),
+        "MyersMinimal output file should exist"
+    );
 }

--- a/libra/tests/command/mod.rs
+++ b/libra/tests/command/mod.rs
@@ -6,12 +6,12 @@ use libra::command::init::init;
 use libra::command::init::InitArgs;
 use libra::command::log::{get_reachable_commits, LogArgs};
 use libra::command::save_object;
-use libra::command::status::{changes_to_be_staged, changes_to_be_committed};
+use libra::command::status::{changes_to_be_committed, changes_to_be_staged};
 use libra::command::switch::{self, check_status, SwitchArgs};
 use libra::command::{
     add::{self, AddArgs},
-    remove::{self, RemoveArgs},
     load_object,
+    remove::{self, RemoveArgs},
 };
 use libra::internal::branch::Branch;
 use libra::internal::head::Head;

--- a/libra/tests/command/remove_test.rs
+++ b/libra/tests/command/remove_test.rs
@@ -1,10 +1,7 @@
-
 use super::*;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
-
-
 
 /// Helper function to create a file with content.
 fn create_file(path: &str, content: &str) -> PathBuf {
@@ -27,7 +24,7 @@ async fn test_remove_single_file() {
 
     // Create a file and add it to index
     let file_path = create_file("test_file.txt", "Test content");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("test_file.txt")],
         all: false,
@@ -52,16 +49,34 @@ async fn test_remove_single_file() {
     remove::execute(args).unwrap();
 
     // Verify the file was removed from the filesystem
-    assert!(!file_path.exists(), "File should be removed from filesystem");
+    assert!(
+        !file_path.exists(),
+        "File should be removed from filesystem"
+    );
 
     // Verify file is no longer in the index
     let changes = changes_to_be_staged();
-    assert!(!changes.new.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as new");
-    assert!(!changes.modified.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as modified");
-    assert!(!changes.deleted.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as deleted");
+    assert!(
+        !changes
+            .new
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as new"
+    );
+    assert!(
+        !changes
+            .modified
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as modified"
+    );
+    assert!(
+        !changes
+            .deleted
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as deleted"
+    );
 }
 
 #[tokio::test]
@@ -74,7 +89,7 @@ async fn test_remove_cached() {
 
     // Create a file and add it to index
     let file_path = create_file("test_file.txt", "Test content");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("test_file.txt")],
         all: false,
@@ -103,8 +118,13 @@ async fn test_remove_cached() {
 
     // Verify file appears as new (untracked) in the index
     let changes = changes_to_be_staged();
-    assert!(changes.new.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should appear in changes as new/untracked");
+    assert!(
+        changes
+            .new
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should appear in changes as new/untracked"
+    );
 }
 
 #[tokio::test]
@@ -119,7 +139,7 @@ async fn test_remove_directory_recursive() {
     let file1 = create_file("test_dir/file1.txt", "File 1 content");
     let file2 = create_file("test_dir/file2.txt", "File 2 content");
     let file3 = create_file("test_dir/subdir/file3.txt", "File 3 content");
-    
+
     // Add all files to the index
     add::execute(AddArgs {
         pathspec: vec![String::from("test_dir")],
@@ -148,7 +168,10 @@ async fn test_remove_directory_recursive() {
     remove::execute(args).unwrap();
 
     // Verify the directory and files were removed
-    assert!(fs::metadata("test_dir").is_err(), "Directory should be removed");
+    assert!(
+        fs::metadata("test_dir").is_err(),
+        "Directory should be removed"
+    );
     assert!(!file1.exists(), "File 1 should be removed");
     assert!(!file2.exists(), "File 2 should be removed");
     assert!(!file3.exists(), "File 3 should be removed");
@@ -157,12 +180,24 @@ async fn test_remove_directory_recursive() {
     let changes = changes_to_be_staged();
     for file in &[file1, file2, file3] {
         let file_str = file.to_str().unwrap();
-        assert!(!changes.new.iter().any(|x| x.to_str().unwrap() == file_str), 
-            "File should not appear in changes as new");
-        assert!(!changes.modified.iter().any(|x| x.to_str().unwrap() == file_str), 
-            "File should not appear in changes as modified");
-        assert!(!changes.deleted.iter().any(|x| x.to_str().unwrap() == file_str), 
-            "File should not appear in changes as deleted");
+        assert!(
+            !changes.new.iter().any(|x| x.to_str().unwrap() == file_str),
+            "File should not appear in changes as new"
+        );
+        assert!(
+            !changes
+                .modified
+                .iter()
+                .any(|x| x.to_str().unwrap() == file_str),
+            "File should not appear in changes as modified"
+        );
+        assert!(
+            !changes
+                .deleted
+                .iter()
+                .any(|x| x.to_str().unwrap() == file_str),
+            "File should not appear in changes as deleted"
+        );
     }
 }
 
@@ -177,7 +212,7 @@ async fn test_remove_directory_without_recursive() {
     // Create a directory with files
     let file1 = create_file("test_dir/file1.txt", "File 1 content");
     let file2 = create_file("test_dir/file2.txt", "File 2 content");
-    
+
     // Add all files to the index
     add::execute(AddArgs {
         pathspec: vec![String::from("test_dir")],
@@ -202,10 +237,16 @@ async fn test_remove_directory_without_recursive() {
         recursive: false,
         force: false,
     };
-    assert!(remove::execute(args).is_err(), "Removing a directory without recursive should fail");
+    assert!(
+        remove::execute(args).is_err(),
+        "Removing a directory without recursive should fail"
+    );
 
     // Verify the directory and files still exist
-    assert!(fs::metadata("test_dir").is_ok(), "Directory should still exist");
+    assert!(
+        fs::metadata("test_dir").is_ok(),
+        "Directory should still exist"
+    );
     assert!(file1.exists(), "File 1 should still exist");
     assert!(file2.exists(), "File 2 should still exist");
 }
@@ -220,7 +261,7 @@ async fn test_remove_untracked_file() {
 
     // Create a file but don't add it to the index
     let file_path = create_file("untracked_file.txt", "Untracked content");
-    
+
     // Make sure the file exists
     assert!(file_path.exists(), "File should exist");
 
@@ -232,7 +273,10 @@ async fn test_remove_untracked_file() {
         force: false,
     };
     let result = remove::execute(args);
-    assert!(result.is_err(), "Removing an untracked file should return an error, not panic");
+    assert!(
+        result.is_err(),
+        "Removing an untracked file should return an error, not panic"
+    );
 
     // Verify the file still exists
     assert!(file_path.exists(), "File should still exist");
@@ -248,7 +292,7 @@ async fn test_remove_modified_file() {
 
     // Create a file and add it to index
     let file_path = create_file("test_file.txt", "Initial content");
-    
+
     add::execute(AddArgs {
         pathspec: vec![String::from("test_file.txt")],
         all: false,
@@ -261,7 +305,11 @@ async fn test_remove_modified_file() {
     .await;
 
     // Modify the file
-    let mut file = fs::OpenOptions::new().write(true).truncate(true).open(&file_path).unwrap();
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&file_path)
+        .unwrap();
     file.write_all(b" - Modified").unwrap();
 
     // Remove the file
@@ -278,12 +326,27 @@ async fn test_remove_modified_file() {
 
     // Verify file is not in the index.
     let changes = changes_to_be_staged();
-    assert!(!changes.new.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as new");
-    assert!(!changes.modified.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as modified");
-    assert!(!changes.deleted.iter().any(|x| x.to_str().unwrap() == "test_file.txt"), 
-        "File should not appear in changes as deleted");
+    assert!(
+        !changes
+            .new
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as new"
+    );
+    assert!(
+        !changes
+            .modified
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as modified"
+    );
+    assert!(
+        !changes
+            .deleted
+            .iter()
+            .any(|x| x.to_str().unwrap() == "test_file.txt"),
+        "File should not appear in changes as deleted"
+    );
 }
 
 #[tokio::test]
@@ -298,7 +361,7 @@ async fn test_remove_multiple_files() {
     let file1 = create_file("file1.txt", "File 1 content");
     let file2 = create_file("file2.txt", "File 2 content");
     let file3 = create_file("file3.txt", "File 3 content");
-    
+
     // Add all files to the index
     add::execute(AddArgs {
         pathspec: vec![String::from(".")],
@@ -323,7 +386,7 @@ async fn test_remove_multiple_files() {
         recursive: false,
         force: false,
     };
-    remove::execute(args).unwrap(); 
+    remove::execute(args).unwrap();
     // Verify the specified files were removed
     assert!(!file1.exists(), "File 1 should be removed");
     assert!(file2.exists(), "File 2 should still exist");

--- a/orion-server/src/server.rs
+++ b/orion-server/src/server.rs
@@ -20,6 +20,7 @@ use utoipa_swagger_ui::SwaggerUi;
     paths(
         api::task_handler,
         api::task_status_handler,
+        api::task_output_handler,
         api::task_query_by_mr,
     ),
     components(


### PR DESCRIPTION
Part of https://github.com/web3infra-foundation/mega/issues/1274
orion-server添加日志输出的swagger-ui，现在可以在网页测试查看输出。
<img width="2161" height="861" alt="image" src="https://github.com/user-attachments/assets/097564e4-747e-412d-abea-5fe5ee3a0ed8" />
<img width="2127" height="1013" alt="image" src="https://github.com/user-attachments/assets/72902f7c-d8ef-445e-8563-3c28a24a9625" />
对于不存在的任务：
<img width="2153" height="1158" alt="image" src="https://github.com/user-attachments/assets/45f72fd2-070d-4c6e-a0be-6ed4f257177b" />
