### PR TITLE
[mono]FEAT: Paging for mr_diff api

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -760,7 +760,12 @@ mod test {
             page_size: page_size as usize,
         };
 
-        assert_eq!(page_info.total_pages, 10);
+            total_pages: (total_files + page_size as usize - 1) / page_size as usize,
+            current_page: current_page as usize,
+            page_size: page_size as usize,
+        };
+
+        assert_eq!(page_info.total_pages, 4);
         assert_eq!(page_info.current_page, 2);
         assert_eq!(page_info.page_size, 3);
     }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -465,7 +465,7 @@ impl MonoApiService {
     }
 
     fn collect_page_blobs(
-        self: &Self,
+        &self,
         items: &[MrDiffFile],
         old_out: &mut Vec<(PathBuf, SHA1)>,
         new_out: &mut Vec<(PathBuf, SHA1)>,
@@ -517,7 +517,7 @@ impl MonoApiService {
 
         // Sort the results
         res.sort_by(|a, b| {
-            a.path().cmp(b.path()).then_with(|| a.kind_weight().cmp(&b.kind_weight()))
+            a.path().cmp(b.path()).then_with(|| a.kind_weight().cmp(b.kind_weight()))
         });
         Ok(res)
     }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -404,7 +404,7 @@ impl MonoApiService {
         let start = (page_id.saturating_sub(1)) * page_size;
         let end = (start + page_size).min(sorted_changed_files.len());
 
-        let page_slice: &[MrDiffFile] = if (start) < sorted_changed_files.len() {
+        let page_slice: &[MrDiffFile] = if start < sorted_changed_files.len() {
             let start_idx = start;
             let end_idx = end;
             &sorted_changed_files[start_idx..end_idx]
@@ -457,7 +457,7 @@ impl MonoApiService {
         Ok(MrDiff {
             data: diff_output,
             page_info: Some(MrPageInfo {
-                total_pages: sorted_changed_files.len(),
+                total_pages: (sorted_changed_files.len() - 1) / page_size + 1,
                 current_page: page_id,
                 page_size,
             })
@@ -517,7 +517,7 @@ impl MonoApiService {
 
         // Sort the results
         res.sort_by(|a, b| {
-            a.path().cmp(b.path()).then_with(|| a.kind_weight().cmp(b.kind_weight()))
+            a.path().cmp(b.path()).then_with(|| a.kind_weight().cmp(&b.kind_weight()))
         });
         Ok(res)
     }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -457,7 +457,7 @@ impl MonoApiService {
         Ok(MrDiff {
             data: diff_output,
             page_info: Some(MrPageInfo {
-                total_pages: (sorted_changed_files.len() + page_size - 1) / page_size,
+                total_pages: (sorted_changed_files.len()-1).div_ceil(page_size),
                 current_page: page_id,
                 page_size,
             })
@@ -755,11 +755,6 @@ mod test {
         let page_size = 3u32;
 
         let page_info = MrPageInfo {
-            total_pages: total_files,
-            current_page: current_page as usize,
-            page_size: page_size as usize,
-        };
-
             total_pages: (total_files + page_size as usize - 1) / page_size as usize,
             current_page: current_page as usize,
             page_size: page_size as usize,

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -457,7 +457,7 @@ impl MonoApiService {
         Ok(MrDiff {
             data: diff_output,
             page_info: Some(MrPageInfo {
-                total_pages: (sorted_changed_files.len() - 1) / page_size + 1,
+                total_pages: (sorted_changed_files.len() + page_size - 1) / page_size,
                 current_page: page_id,
                 page_size,
             })

--- a/ceres/src/model/mr.rs
+++ b/ceres/src/model/mr.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-
+use utoipa::ToSchema;
 use mercury::hash::SHA1;
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
@@ -9,6 +9,37 @@ pub enum MrDiffFile {
     Deleted(PathBuf, SHA1),
     // path, old_hash, new_hash
     Modified(PathBuf, SHA1, SHA1),
+}
+
+impl MrDiffFile {
+    pub fn path(&self) -> &PathBuf {
+        match self {
+            MrDiffFile::New(path, _) => path,
+            MrDiffFile::Deleted(path, _) => path,
+            MrDiffFile::Modified(path, _, _) => path,
+        }
+    }
+
+    pub fn kind_weight(&self) -> &PathBuf {
+        match self {
+            MrDiffFile::New(path, _) 
+            | MrDiffFile::Deleted(path, _)
+            | MrDiffFile::Modified(path, _, _) => path,
+        }
+    }
+}
+
+#[derive(Debug, ToSchema, Serialize, Deserialize)]
+pub struct MrDiff {
+    pub data: String,
+    pub page_info: Option<MrPageInfo>,
+}
+
+#[derive(Debug, ToSchema, Serialize, Deserialize)]
+pub struct MrPageInfo {
+    pub total_pages: usize,
+    pub current_page: usize,
+    pub page_size: usize,
 }
 
 #[derive(Serialize)]

--- a/ceres/src/model/mr.rs
+++ b/ceres/src/model/mr.rs
@@ -20,11 +20,11 @@ impl MrDiffFile {
         }
     }
 
-    pub fn kind_weight(&self) -> &PathBuf {
+    pub fn kind_weight(&self) -> u8 {
         match self {
-            MrDiffFile::New(path, _) 
-            | MrDiffFile::Deleted(path, _)
-            | MrDiffFile::Modified(path, _, _) => path,
+            MrDiffFile::New(_, _) => 0,
+            MrDiffFile::Deleted(_, _) => 1,
+            MrDiffFile::Modified(_, _, _) => 2,
         }
     }
 }

--- a/mono/src/api/mr/mod.rs
+++ b/mono/src/api/mr/mod.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ceres::model::mr::MrDiffFile;
+use ceres::model::mr::{MrDiff, MrDiffFile};
 use jupiter::model::mr_dto::MRDetails;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -52,7 +52,7 @@ impl From<MRDetails> for MRDetailRes {
 #[derive(Serialize, ToSchema)]
 pub struct FilesChangedList {
     pub mui_trees: Vec<MuiTreeNode>,
-    pub content: String,
+    pub content: MrDiff,
 }
 
 #[derive(Serialize, Debug, ToSchema)]

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -263,7 +263,7 @@ async fn mr_detail(
     params(
         ("link", description = "MR link"),
     ),
-    path = "/{link}/files-changed",
+    path = "/{link}/files-changed/{page_id}/{page_size}",
     responses(
         (status = 200, body = CommonResult<FilesChangedList>, content_type = "application/json")
     ),
@@ -271,11 +271,16 @@ async fn mr_detail(
 )]
 async fn mr_files_changed(
     Path(link): Path<String>,
+    Path(page_id): Path<usize>,
+    Path(page_size): Path<usize>,
     state: State<MonoApiServiceState>,
 ) -> Result<Json<CommonResult<FilesChangedList>>, ApiError> {
-    let diff_res = state.monorepo().content_diff(&link).await?;
+    let diff_res = state
+        .monorepo()
+        .content_diff(&link, page_id, page_size)
+        .await?;
 
-    let diff_files = extract_files_with_status(&diff_res);
+    let diff_files = extract_files_with_status(&diff_res.data);
     let mut paths = vec![];
     for (path, _) in diff_files {
         paths.push(path);
@@ -463,9 +468,10 @@ fn build_forest(paths: Vec<String>) -> Vec<MuiTreeNode> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+    use ceres::model::mr::MrDiff;
     use crate::api::mr::mr_router::{build_forest, extract_files_with_status};
     use crate::api::mr::FilesChangedList;
-    use std::collections::HashMap;
 
     #[test]
     fn test_parse_diff_result_to_filelist() {
@@ -519,7 +525,7 @@ mod test {
     fn test_mr_files_changed_logic() {
         // Test the core logic of mr_files_changed function
         // This tests the data transformation logic without needing the full state
-
+        
         let sample_diff_output = r#"diff --git a/src/main.rs b/src/main.rs
             new file mode 100644
             index 0000000..abc1234
@@ -544,7 +550,7 @@ mod test {
 
         // Test extract_files_with_status
         let diff_files = extract_files_with_status(sample_diff_output);
-
+        
         assert_eq!(diff_files.len(), 3);
         assert_eq!(diff_files.get("src/main.rs"), Some(&"new".to_string()));
         assert_eq!(diff_files.get("src/lib.rs"), Some(&"modified".to_string()));
@@ -555,25 +561,30 @@ mod test {
         for (path, _) in diff_files {
             paths.push(path);
         }
-
+        
         let mui_trees = build_forest(paths);
-
+        
         // Verify the tree structure
         assert!(!mui_trees.is_empty());
-
+        
         // Check that we have the expected root nodes
         let root_labels: Vec<&str> = mui_trees.iter().map(|tree| tree.label.as_str()).collect();
         assert!(root_labels.contains(&"src"));
         assert!(root_labels.contains(&"README.md"));
+        
+        let content = MrDiff {
+            data: sample_diff_output.to_string(),
+            page_info: None 
+        };
 
         // Test the complete response structure
         let files_changed_list = FilesChangedList {
             mui_trees,
-            content: sample_diff_output.to_string(),
+            content,
         };
-
+        
         assert!(!files_changed_list.mui_trees.is_empty());
-        assert_eq!(files_changed_list.content, sample_diff_output);
+        assert_eq!(files_changed_list.content.data, sample_diff_output);
     }
 
     #[test]
@@ -594,7 +605,7 @@ new file mode 100644
 index 0000000..1234567
 --- /dev/null
 +++ b/new_file.txt"#;
-
+        
         let result = extract_files_with_status(additions_only);
         assert_eq!(result.len(), 1);
         assert_eq!(result.get("new_file.txt"), Some(&"new".to_string()));
@@ -603,7 +614,7 @@ index 0000000..1234567
         let deletions_only = r#"diff --git a/old_file.txt b/old_file.txt
 deleted file mode 100644
 index 1234567..0000000"#;
-
+        
         let result = extract_files_with_status(deletions_only);
         assert_eq!(result.len(), 1);
         assert_eq!(result.get("old_file.txt"), Some(&"deleted".to_string()));
@@ -631,7 +642,7 @@ index 1234567..0000000"#;
         let result = build_forest(nested_paths);
         assert_eq!(result.len(), 1); // Should have one root "a"
         assert_eq!(result[0].label, "a");
-
+        
         // The tree should have nested structure
         let root = &result[0];
         assert!(root.children.is_some());


### PR DESCRIPTION
### Merge Request Diff Pagination and API Refactor

- Update the `content_diff` method in `Ceres/MonoApiService`
    - new parameter: `page_id`, `page_size`
    - new returning: from `String· to `MrDiff`
    - `page_id` out of range will receive an **empty vec**

- Created new structure `MrDiff` to return wrapped diff data and page info.

- New API URL: `/api/v1/mr/{link}/files-changed/{page_id}/{page_size}`

Closes #1298 