### PR TITLE
[mono]UPDATE: Alter to CommonPage and Restored content_diff for debug…

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -974,11 +974,6 @@ mod test {
         use mercury::internal::object::blob::Blob;
         use std::collections::HashMap;
 
-        // Create a service with mock storage
-        let service = MonoApiService {
-            storage: Storage::mock(),
-        };
-
         // Test basic diff generation with sample data
         let old_content = "Hello World\nLine 2\nLine 3";
         let new_content = "Hello Universe\nLine 2\nLine 3 modified";

--- a/ceres/src/model/mr.rs
+++ b/ceres/src/model/mr.rs
@@ -30,19 +30,6 @@ impl MrDiffFile {
     }
 }
 
-// #[derive(Debug, ToSchema, Serialize, Deserialize)]
-// pub struct MrDiff {
-//     pub data: String,
-//     pub page_info: Option<MrPageInfo>,
-// }
-
-// #[derive(Debug, ToSchema, Serialize, Deserialize)]
-// pub struct MrPageInfo {
-//     pub total_pages: usize,
-//     pub current_page: usize,
-//     pub page_size: usize,
-// }
-
 #[derive(Serialize)]
 pub struct BuckFile {
     pub buck: SHA1,

--- a/ceres/src/model/mr.rs
+++ b/ceres/src/model/mr.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 use mercury::hash::SHA1;
 
@@ -31,18 +30,18 @@ impl MrDiffFile {
     }
 }
 
-#[derive(Debug, ToSchema, Serialize, Deserialize)]
-pub struct MrDiff {
-    pub data: String,
-    pub page_info: Option<MrPageInfo>,
-}
+// #[derive(Debug, ToSchema, Serialize, Deserialize)]
+// pub struct MrDiff {
+//     pub data: String,
+//     pub page_info: Option<MrPageInfo>,
+// }
 
-#[derive(Debug, ToSchema, Serialize, Deserialize)]
-pub struct MrPageInfo {
-    pub total_pages: usize,
-    pub current_page: usize,
-    pub page_size: usize,
-}
+// #[derive(Debug, ToSchema, Serialize, Deserialize)]
+// pub struct MrPageInfo {
+//     pub total_pages: usize,
+//     pub current_page: usize,
+//     pub page_size: usize,
+// }
 
 #[derive(Serialize)]
 pub struct BuckFile {

--- a/common/src/model.rs
+++ b/common/src/model.rs
@@ -77,7 +77,6 @@ pub struct PageParams<T> {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
-
 pub struct CommonPage<T> {
     pub total: u64,
     pub items: Vec<T>,

--- a/libra/src/command/diff.rs
+++ b/libra/src/command/diff.rs
@@ -147,10 +147,12 @@ pub async fn execute(args: DiffArgs) {
     )
     .await;
 
+    let results: Vec<String> = diff_output.iter().map(|i| i.data.clone()).collect();
+
     // Handle output - libra processes the string according to its needs
     match w {
         Some(ref mut file) => {
-            file.write_all(diff_output.as_bytes()).unwrap();
+            file.write_all(results.join("\n").as_bytes()).unwrap();
         }
         None => {
             #[cfg(unix)]
@@ -162,7 +164,7 @@ pub async fn execute(args: DiffArgs) {
                     .spawn()
                     .expect("failed to execute process");
                 let stdin = child.stdin.as_mut().unwrap();
-                stdin.write_all(diff_output.as_bytes()).unwrap();
+                stdin.write_all(results.join("\n").as_bytes()).unwrap();
                 child.wait().unwrap();
             }
             #[cfg(not(unix))]

--- a/libra/src/command/diff.rs
+++ b/libra/src/command/diff.rs
@@ -152,7 +152,7 @@ pub async fn execute(args: DiffArgs) {
     // Handle output - libra processes the string according to its needs
     match w {
         Some(ref mut file) => {
-            file.write_all(results.join("\n").as_bytes()).unwrap();
+            file.write_all(results.join("").as_bytes()).unwrap();
         }
         None => {
             #[cfg(unix)]
@@ -164,7 +164,7 @@ pub async fn execute(args: DiffArgs) {
                     .spawn()
                     .expect("failed to execute process");
                 let stdin = child.stdin.as_mut().unwrap();
-                stdin.write_all(results.join("\n").as_bytes()).unwrap();
+                stdin.write_all(results.join("").as_bytes()).unwrap();
                 child.wait().unwrap();
             }
             #[cfg(not(unix))]

--- a/mono/Cargo.toml
+++ b/mono/Cargo.toml
@@ -59,6 +59,7 @@ utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-axum = { workspace = true }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 uuid = { workspace = true, features = ["v4"] }
+neptune = { workspace = true }
 
 
 

--- a/mono/src/api/mr/mod.rs
+++ b/mono/src/api/mr/mod.rs
@@ -1,14 +1,15 @@
 use std::str::FromStr;
 
-use ceres::model::mr::{MrDiff, MrDiffFile};
+use ceres::model::mr::MrDiffFile;
 use jupiter::model::mr_dto::MRDetails;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use callisto::sea_orm_active_enums::MergeStatusEnum;
-
 use crate::api::{conversation::ConversationItem, label::LabelItem};
+use callisto::sea_orm_active_enums::MergeStatusEnum;
+use common::model::CommonPage;
+use neptune::model::diff_model::DiffItem;
 
 pub mod mr_router;
 
@@ -52,7 +53,13 @@ impl From<MRDetails> for MRDetailRes {
 #[derive(Serialize, ToSchema)]
 pub struct FilesChangedList {
     pub mui_trees: Vec<MuiTreeNode>,
-    pub content: MrDiff,
+    pub content: Vec<DiffItem>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct FilesChangedPage {
+    page: CommonPage<DiffItem>,
+    mui_trees: Vec<MuiTreeNode>,
 }
 
 #[derive(Serialize, Debug, ToSchema)]

--- a/mono/src/api/mr/mod.rs
+++ b/mono/src/api/mr/mod.rs
@@ -58,8 +58,8 @@ pub struct FilesChangedList {
 
 #[derive(Serialize, ToSchema)]
 pub struct FilesChangedPage {
-    page: CommonPage<DiffItem>,
-    mui_trees: Vec<MuiTreeNode>,
+    pub mui_trees: Vec<MuiTreeNode>,
+    pub page: CommonPage<DiffItem>,
 }
 
 #[derive(Serialize, Debug, ToSchema)]

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -258,6 +258,7 @@ async fn mr_detail(
     Ok(Json(CommonResult::success(Some(mr_details))))
 }
 
+/// Get List of All Changed Files in Merge Request
 #[utoipa::path(
     get,
     params(
@@ -284,7 +285,7 @@ async fn mr_files_changed(
     Ok(Json(res))
 }
 
-/// Get Merge Request file changed list
+/// Get Merge Request file changed list in Pagination
 #[utoipa::path(
     post,
     params(
@@ -411,26 +412,6 @@ async fn edit_title(
     state.mr_stg().edit_title(&link, &payload.content).await?;
     Ok(Json(CommonResult::success(None)))
 }
-
-// fn extract_files_with_status(diff_output: &str) -> HashMap<String, String> {
-//     let mut files = HashMap::new();
-//
-//     let chunks: Vec<&str> = diff_output.split("diff --git ").collect();
-//
-//     for chunk in chunks.iter().skip(1) {
-//         let lines: Vec<&str> = chunk.split_whitespace().collect();
-//         if lines.len() >= 2 {
-//             let current_file = lines[0].trim_start_matches("a/").to_string();
-//             files.insert(current_file.clone(), "modified".to_string()); // 默认状态为修改
-//             if chunk.contains("new file mode") {
-//                 files.insert(current_file, "new".to_string());
-//             } else if chunk.contains("deleted file mode") {
-//                 files.insert(current_file, "deleted".to_string());
-//             }
-//         }
-//     }
-//     files
-// }
 
 /// Update mr related labels
 #[utoipa::path(

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -616,11 +616,10 @@ mod test {
         assert!(root_labels.contains(&"src"));
         assert!(root_labels.contains(&"README.md"));
 
-        let mut content = Vec::new();
-        content.push(DiffItem {
+        let content = vec![DiffItem {
             data: sample_diff_output.to_string(),
             path: "diff_output.txt".to_string(),
-        });
+        }];
 
         // Test the complete response structure
         let files_changed_list = FilesChangedList { mui_trees, content };

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use axum::{
     extract::{Path, State},
@@ -13,7 +13,6 @@ use common::{
     model::{CommonPage, CommonResult, PageParams},
 };
 
-use crate::api::MonoApiServiceState;
 use crate::api::{
     api_common::{
         self,
@@ -25,6 +24,7 @@ use crate::api::{
     mr::{FilesChangedList, MRDetailRes, MrFilesRes, MuiTreeNode},
     oauth::model::LoginUser,
 };
+use crate::api::{mr::FilesChangedPage, MonoApiServiceState};
 use crate::{api::error::ApiError, server::http_server::MR_TAG};
 
 pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
@@ -37,6 +37,7 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
             .routes(routes!(merge_no_auth))
             .routes(routes!(close_mr))
             .routes(routes!(reopen_mr))
+            .routes(routes!(mr_files_changed_by_page))
             .routes(routes!(mr_files_changed))
             .routes(routes!(mr_files_list))
             .routes(routes!(save_comment))
@@ -257,13 +258,12 @@ async fn mr_detail(
     Ok(Json(CommonResult::success(Some(mr_details))))
 }
 
-/// Get Merge Request file changed list
 #[utoipa::path(
     get,
     params(
         ("link", description = "MR link"),
     ),
-    path = "/{link}/files-changed/{page_id}/{page_size}",
+    path = "/{link}/files-changed",
     responses(
         (status = 200, body = CommonResult<FilesChangedList>, content_type = "application/json")
     ),
@@ -271,24 +271,48 @@ async fn mr_detail(
 )]
 async fn mr_files_changed(
     Path(link): Path<String>,
-    Path(page_id): Path<usize>,
-    Path(page_size): Path<usize>,
     state: State<MonoApiServiceState>,
 ) -> Result<Json<CommonResult<FilesChangedList>>, ApiError> {
-    let diff_res = state
-        .monorepo()
-        .content_diff(&link, page_id, page_size)
-        .await?;
+    let diff_res = state.monorepo().content_diff(&link).await?;
 
-    let diff_files = extract_files_with_status(&diff_res.data);
-    let mut paths = vec![];
-    for (path, _) in diff_files {
-        paths.push(path);
-    }
+    let paths = diff_res.iter().map(|i| i.path.clone()).collect();
     let mui_trees = build_forest(paths);
     let res = CommonResult::success(Some(FilesChangedList {
         mui_trees,
         content: diff_res,
+    }));
+    Ok(Json(res))
+}
+
+/// Get Merge Request file changed list
+#[utoipa::path(
+    post,
+    params(
+        ("link", description = "MR link"),
+    ),
+    path = "/{link}/files-changed",
+    request_body = PageParams<ListPayload>,
+    responses(
+        (status = 200, body = CommonResult<FilesChangedPage>, content_type = "application/json")
+    ),
+    tag = MR_TAG
+)]
+#[axum::debug_handler]
+async fn mr_files_changed_by_page(
+    Path(link): Path<String>,
+    state: State<MonoApiServiceState>,
+    Json(json): Json<PageParams<ListPayload>>,
+) -> Result<Json<CommonResult<FilesChangedPage>>, ApiError> {
+    let (items, total) = state
+        .monorepo()
+        .paged_content_diff(&link, json.pagination)
+        .await?;
+
+    let paths = items.iter().map(|i| i.path.clone()).collect();
+    let mui_trees = build_forest(paths);
+    let res = CommonResult::success(Some(FilesChangedPage {
+        mui_trees,
+        page: CommonPage { total, items },
     }));
     Ok(Json(res))
 }
@@ -388,25 +412,25 @@ async fn edit_title(
     Ok(Json(CommonResult::success(None)))
 }
 
-fn extract_files_with_status(diff_output: &str) -> HashMap<String, String> {
-    let mut files = HashMap::new();
-
-    let chunks: Vec<&str> = diff_output.split("diff --git ").collect();
-
-    for chunk in chunks.iter().skip(1) {
-        let lines: Vec<&str> = chunk.split_whitespace().collect();
-        if lines.len() >= 2 {
-            let current_file = lines[0].trim_start_matches("a/").to_string();
-            files.insert(current_file.clone(), "modified".to_string()); // 默认状态为修改
-            if chunk.contains("new file mode") {
-                files.insert(current_file, "new".to_string());
-            } else if chunk.contains("deleted file mode") {
-                files.insert(current_file, "deleted".to_string());
-            }
-        }
-    }
-    files
-}
+// fn extract_files_with_status(diff_output: &str) -> HashMap<String, String> {
+//     let mut files = HashMap::new();
+//
+//     let chunks: Vec<&str> = diff_output.split("diff --git ").collect();
+//
+//     for chunk in chunks.iter().skip(1) {
+//         let lines: Vec<&str> = chunk.split_whitespace().collect();
+//         if lines.len() >= 2 {
+//             let current_file = lines[0].trim_start_matches("a/").to_string();
+//             files.insert(current_file.clone(), "modified".to_string()); // 默认状态为修改
+//             if chunk.contains("new file mode") {
+//                 files.insert(current_file, "new".to_string());
+//             } else if chunk.contains("deleted file mode") {
+//                 files.insert(current_file, "deleted".to_string());
+//             }
+//         }
+//     }
+//     files
+// }
 
 /// Update mr related labels
 #[utoipa::path(
@@ -468,10 +492,30 @@ fn build_forest(paths: Vec<String>) -> Vec<MuiTreeNode> {
 
 #[cfg(test)]
 mod test {
-    use crate::api::mr::mr_router::{build_forest, extract_files_with_status};
+    use crate::api::mr::mr_router::build_forest;
     use crate::api::mr::FilesChangedList;
-    use ceres::model::mr::MrDiff;
+    use neptune::model::diff_model::DiffItem;
     use std::collections::HashMap;
+
+    fn extract_files_with_status(diff_output: &str) -> HashMap<String, String> {
+        let mut files = HashMap::new();
+
+        let chunks: Vec<&str> = diff_output.split("diff --git ").collect();
+
+        for chunk in chunks.iter().skip(1) {
+            let lines: Vec<&str> = chunk.split_whitespace().collect();
+            if lines.len() >= 2 {
+                let current_file = lines[0].trim_start_matches("a/").to_string();
+                files.insert(current_file.clone(), "modified".to_string()); // 默认状态为修改
+                if chunk.contains("new file mode") {
+                    files.insert(current_file, "new".to_string());
+                } else if chunk.contains("deleted file mode") {
+                    files.insert(current_file, "deleted".to_string());
+                }
+            }
+        }
+        files
+    }
 
     #[test]
     fn test_parse_diff_result_to_filelist() {
@@ -572,16 +616,20 @@ mod test {
         assert!(root_labels.contains(&"src"));
         assert!(root_labels.contains(&"README.md"));
 
-        let content = MrDiff {
+        let mut content = Vec::new();
+        content.push(DiffItem {
             data: sample_diff_output.to_string(),
-            page_info: None,
-        };
+            path: "diff_output.txt".to_string(),
+        });
 
         // Test the complete response structure
         let files_changed_list = FilesChangedList { mui_trees, content };
 
         assert!(!files_changed_list.mui_trees.is_empty());
-        assert_eq!(files_changed_list.content.data, sample_diff_output);
+        assert_eq!(
+            files_changed_list.content.first().unwrap().data,
+            sample_diff_output
+        );
     }
 
     #[test]

--- a/neptune/Cargo.toml
+++ b/neptune/Cargo.toml
@@ -8,3 +8,5 @@ infer = { workspace = true }
 mercury = { workspace = true }
 path-absolutize = { workspace = true }
 tracing = { workspace = true }
+utoipa = { workspace = true }
+serde = { workspace = true }

--- a/neptune/src/lib.rs
+++ b/neptune/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod model;
 pub mod neptune_engine;
 
 pub use neptune_engine::Diff;

--- a/neptune/src/model/diff_model.rs
+++ b/neptune/src/model/diff_model.rs
@@ -1,0 +1,8 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Serialize, ToSchema)]
+pub struct DiffItem {
+    pub path: String,
+    pub data: String,
+}

--- a/neptune/src/model/mod.rs
+++ b/neptune/src/model/mod.rs
@@ -1,0 +1,1 @@
+pub mod diff_model;

--- a/neptune/src/neptune_engine.rs
+++ b/neptune/src/neptune_engine.rs
@@ -61,7 +61,7 @@ impl Diff {
                 Self::is_large_file(&file, &old_blobs_map, &new_blobs_map, &read_content)
             {
                 diff_results.push(DiffItem {
-                    path: file.to_str().unwrap().to_string(),
+                    path: file.to_string_lossy().to_string(),
                     data: large_file_marker,
                 });
             } else {
@@ -73,7 +73,7 @@ impl Diff {
                     &read_content,
                 );
                 diff_results.push(DiffItem {
-                    path: file.to_str().unwrap().to_string(),
+                    path: file.to_string_lossy().to_string(),
                     data: diff,
                 });
             }

--- a/neptune/src/neptune_engine.rs
+++ b/neptune/src/neptune_engine.rs
@@ -1,3 +1,4 @@
+use crate::model::diff_model::DiffItem;
 use infer;
 use mercury::hash::SHA1;
 use path_absolutize::Absolutize;
@@ -47,7 +48,7 @@ impl Diff {
         algorithm: String,
         filter: Vec<PathBuf>,
         read_content: F,
-    ) -> String
+    ) -> Vec<DiffItem>
     where
         F: Fn(&PathBuf, &SHA1) -> Vec<u8>,
     {
@@ -59,7 +60,10 @@ impl Diff {
             if let Some(large_file_marker) =
                 Self::is_large_file(&file, &old_blobs_map, &new_blobs_map, &read_content)
             {
-                diff_results.push(large_file_marker);
+                diff_results.push(DiffItem {
+                    path: file.to_str().unwrap().to_string(),
+                    data: large_file_marker,
+                });
             } else {
                 let diff = Self::diff_for_file_string(
                     &file,
@@ -68,11 +72,14 @@ impl Diff {
                     algorithm.as_str(),
                     &read_content,
                 );
-                diff_results.push(diff);
+                diff_results.push(DiffItem {
+                    path: file.to_str().unwrap().to_string(),
+                    data: diff,
+                });
             }
         }
 
-        diff_results.join("")
+        diff_results
     }
 
     /// Checks if a file is large and returns a message if it is.


### PR DESCRIPTION
Update #1298 

### API and Model

- Restored the old `files_changed` API for debugging
- Changed `page_id/page_size` path parameters to pagination request body
- Now uses a new `DiffItem` model to store all the file diff data

### Services Change

- mono service `content_diff` and `paged_content_diff` now return a list of `DiffItem` instead of String
- removed extract_files_service due to improved content_diff function