### PR TITLE
feat(init): add --template option, Issue: #1340

### DIFF
--- a/aria/contents/docs/libra/command/init/index.mdx
+++ b/aria/contents/docs/libra/command/init/index.mdx
@@ -22,6 +22,8 @@ which sets up the repository without a working directory, containing only Libra 
     <Note type="danger" title="Git bare VS Libra bare">
     **Note**：Unlike Git's `--bare`, the Libra init `--bare` initializes a bare repository that contains Libra's own SQLite database.
     </Note>
+-   `--template <template-directory>`
+    Specify a directory from which templates will be used to initialize the repository.
 -   `-b`, `--initial-branch <INITIAL_BRANCH>`
     Override the name of the initial branch
 -   `-h`, `--help` Print help

--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -88,6 +88,7 @@ pub async fn execute(args: CloneArgs) {
         initial_branch: args.branch.clone(),
         repo_directory: local_path.to_str().unwrap().to_string(),
         quiet: false,
+        template: None,
     };
     command::init::execute(init_args).await;
 

--- a/libra/src/command/init.rs
+++ b/libra/src/command/init.rs
@@ -86,7 +86,12 @@ fn is_writable(cur_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Recursively copy the contents of the template directory to the destination directory
+/// Recursively copy the contents of the template directory to the destination directory.
+///
+/// # Behavior
+/// - Directories are created as needed.
+/// - Existing files in `dst` are NOT overwritten.
+/// - Subdirectories are copied recursively.
 fn copy_template(src: &Path, dst: &Path) -> io::Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
@@ -96,11 +101,9 @@ fn copy_template(src: &Path, dst: &Path) -> io::Result<()> {
         if file_type.is_dir() {
             fs::create_dir_all(&dest_path)?;
             copy_template(&entry.path(), &dest_path)?;
-        } else {
-            if !dest_path.exists() {
-                // Only copy if the file does not already exist
-                fs::copy(entry.path(), &dest_path)?;
-            }
+        } else if !dest_path.exists() {
+            // Only copy if the file does not already exist
+            fs::copy(entry.path(), &dest_path)?;
         }
     }
     Ok(())

--- a/libra/src/utils/test.rs
+++ b/libra/src/utils/test.rs
@@ -106,6 +106,7 @@ pub async fn setup_with_new_libra_in(temp_path: impl AsRef<Path>) {
         initial_branch: None,
         repo_directory: temp_path.as_ref().to_str().unwrap().to_string(),
         quiet: false,
+        template: None,
     };
     command::init::init(args).await.unwrap();
 }

--- a/libra/tests/command/checkout_test.rs
+++ b/libra/tests/command/checkout_test.rs
@@ -64,6 +64,7 @@ async fn test_checkout_module_functions() {
         initial_branch: Some("main".to_string()),
         repo_directory: temp_path.path().to_str().unwrap().to_string(),
         quiet: false,
+        template: None,
     };
 
     init::init(init_args)

--- a/libra/tests/command/init_test.rs
+++ b/libra/tests/command/init_test.rs
@@ -119,7 +119,6 @@ async fn test_init_template() {
     );
 }
 
-
 #[tokio::test]
 #[serial]
 /// Test the init function with an invalid template path
@@ -156,7 +155,6 @@ async fn test_init_with_invalid_template_path() {
         println!("Received expected error: {:?}", err);
     }
 }
-
 
 #[tokio::test]
 #[serial]


### PR DESCRIPTION
## 功能简介
在 `init` 命令中新增 `--template <template-directory>` 参数，用于从指定模板目录初始化 Libra 仓库。
如果未指定，仍使用默认模板。

## 修改内容
- 更新 `init` 命令逻辑，支持 `--template` 参数
- 增加测试用例，覆盖：
  - 指定有效模板目录
  - 模板目录不存在
- 修改 Aria 模块对应的命令描述：
  - 使用 Aira Docs 模板更新 `init` 命令文档

## 测试情况
- `cargo test` 运行所有单元测试及集成测试，确保功能正常
- 验证模板文件能够正确复制到新仓库目录
- 检查 Aria 文档页面显示正确

## Issue
#1340