### PR TITLE
chore:replace the host by hard code

### DIFF
--- a/moon/apps/web/components/MrView/hook/useSSM.ts
+++ b/moon/apps/web/components/MrView/hook/useSSM.ts
@@ -3,6 +3,9 @@ import { useAtom } from 'jotai'
 
 import { loadingAtom, logsAtom, statusAtom } from '../components/Checks/cpns/store'
 
+// TODO：request path should be set by the environment val
+export const SSEPATH = window.location.href.includes('app') ? 'https://orion.gitmega.com/' : '/sse/'
+
 export const useSSM = () => {
   const sseUrl = useRef('')
   const createEventSource = (baseUrl: string): Promise<EventSource> => {
@@ -39,8 +42,13 @@ export const useTaskSSE = () => {
 
   const setEventSource: (taskId: string) => void = (taskId: string) => {
     if (eventSourcesRef.current[taskId]) return
-    const es = new EventSource(`/sse/task-output/${taskId}`)
+    // proxy
+    // const es = new EventSource(`/sse/task-output/${taskId}`)
+
+    // mock
     // const es = new EventSource(`/api/event?id=${taskId}`)
+
+    const es = new EventSource(`${SSEPATH}task-output/${taskId}`)
 
     es.onmessage = (e) => {
       setLogsMap((prev) => {
@@ -112,7 +120,7 @@ export const useMultiTaskSSE = (taskIds: string[]) => {
     taskIds.forEach((taskId) => {
       if (!eventSourcesRef.current[taskId]) {
         // const es = new EventSource(`/api/tasks/${taskId}/events`)
-        const es = new EventSource(`/sse/task-output/${taskId}`)
+        const es = new EventSource(`${SSEPATH}/task-output/${taskId}`)
 
         es.onmessage = (e) => {
           setEventsMap((prev) => {

--- a/moon/apps/web/hooks/SSE/ssmRequest.ts
+++ b/moon/apps/web/hooks/SSE/ssmRequest.ts
@@ -1,3 +1,5 @@
+import { SSEPATH } from '@/components/MrView/hook/useSSM'
+
 import { HTTPLogRes } from './useGetHTTPLog'
 
 export const fetchTask = async (mr: string) => {
@@ -43,7 +45,8 @@ export const MrTaskStatus = async (mr: string) => {
 }
 
 export const HttpTaskRes = async (taskId: string, offset: number, len: number): Promise<HTTPLogRes> => {
-  const res = await fetch(`/sse/task-output-segment/${taskId}?offset=${offset}&len=${len}`, {
+  const res = await fetch(`${SSEPATH}task-output-segment/${taskId}?offset=${offset}&len=${len}`, {
+  // const res = await fetch(`/sse/task-output-segment/${taskId}?offset=${offset}&len=${len}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json'


### PR DESCRIPTION
通过硬编码替换sse 请求端口

通过判断当前url是否包括app调整端口
原因：sse部分接口没有进行跨域配置（taskoutput-segment）
并且前端本地开发时仍然会出现跨域报错（不影响请求）