### PR TITLE
fix(libra): clone remote repo gets error, remote reference names in db are wrong.

### DIFF
--- a/libra/src/command/clone.rs
+++ b/libra/src/command/clone.rs
@@ -15,8 +15,6 @@ use std::cell::Cell;
 use std::path::PathBuf;
 use std::{env, fs};
 
-const ORIGIN: &str = "origin"; // default remote name, prevent spelling mistakes
-
 #[derive(Parser, Debug)]
 pub struct CloneArgs {
     /// The remote repository location to clone from, usually a URL with HTTPS or SSH

--- a/libra/src/command/fetch.rs
+++ b/libra/src/command/fetch.rs
@@ -239,7 +239,7 @@ pub async fn fetch_repository(remote_config: RemoteConfig, branch: Option<String
                     } else if let Some(mr_name) = r._ref.strip_prefix("refs/mr/") {
                         // Handle merge requests if your system supports them
                         full_ref_name = format!("mr/{}", mr_name);
-                    } else if &r._ref == HEAD {
+                    } else if r._ref == HEAD {
                         continue;
                     } else {
                         tracing::warn!("Unsupported ref type during fetch: {}", r._ref);

--- a/libra/src/command/fetch.rs
+++ b/libra/src/command/fetch.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::io::StreamReader;
 use url::Url;
 
-use crate::command::load_object;
+use crate::command::{load_object, HEAD};
 use crate::internal::db::get_db_conn_instance;
 use crate::internal::reflog;
 use crate::internal::reflog::{zero_sha1, ReflogAction, ReflogContext, ReflogError};
@@ -235,24 +235,34 @@ pub async fn fetch_repository(remote_config: RemoteConfig, branch: Option<String
 
                     // Determine the full ref name (e.g., "refs/remotes/origin/main")
                     if let Some(branch_name) = r._ref.strip_prefix("refs/heads/") {
-                        full_ref_name =
-                            format!("refs/remotes/{}/{}", remote_config.name, branch_name);
+                        full_ref_name = branch_name.to_owned();
                     } else if let Some(mr_name) = r._ref.strip_prefix("refs/mr/") {
                         // Handle merge requests if your system supports them
-                        full_ref_name =
-                            format!("refs/remotes/{}/mr/{}", remote_config.name, mr_name);
+                        full_ref_name = format!("mr/{}", mr_name);
+                    } else if &r._ref == HEAD {
+                        continue;
                     } else {
                         tracing::warn!("Unsupported ref type during fetch: {}", r._ref);
                         continue; // Skip unsupported ref types
                     }
 
                     // Get the old OID *before* updating the branch
-                    let old_oid = Branch::find_branch_with_conn(txn, &full_ref_name, None)
-                        .await
-                        .map_or(zero_sha1().to_string(), |b| b.commit.to_string());
+                    let old_oid = Branch::find_branch_with_conn(
+                        txn,
+                        &full_ref_name,
+                        Some(&remote_config.name),
+                    )
+                    .await
+                    .map_or(zero_sha1().to_string(), |b| b.commit.to_string());
 
                     // Update the branch pointer
-                    Branch::update_branch_with_conn(txn, &full_ref_name, &r._hash, None).await;
+                    Branch::update_branch_with_conn(
+                        txn,
+                        &full_ref_name,
+                        &r._hash,
+                        Some(&remote_config.name),
+                    )
+                    .await;
 
                     // Prepare and insert the reflog entry for this specific remote-tracking branch
                     let context = ReflogContext {

--- a/libra/src/internal/config.rs
+++ b/libra/src/internal/config.rs
@@ -11,6 +11,7 @@ use crate::internal::model::config::{self, ActiveModel, Model};
 
 pub struct Config;
 
+#[derive(Clone)]
 pub struct RemoteConfig {
     pub name: String,
     pub url: String,


### PR DESCRIPTION
Should close #1384 

## Description
After getting remote refs from remote repo, remote branch names saved in the libra.db should not include the prefix `refs/remote/origin` and the `remote` column should be **origin**.