### PR TITLE
feat(Mono&&UI): Implement UI for creating nested directories or file and add corresponding backend API endpoints.

### DIFF
--- a/ceres/src/api_service/import_api_service.rs
+++ b/ceres/src/api_service/import_api_service.rs
@@ -17,7 +17,7 @@ use jupiter::storage::Storage;
 
 use crate::api_service::{ApiHandler, GitObjectCache};
 use crate::model::blame::{BlameQuery, BlameResult};
-use crate::model::git::CreateFileInfo;
+use crate::model::git::CreateEntryInfo;
 use crate::protocol::repo::Repo;
 use callisto::{git_tag, import_refs};
 
@@ -33,9 +33,9 @@ impl ApiHandler for ImportApiService {
         self.storage.clone()
     }
 
-    async fn create_monorepo_file(&self, _: CreateFileInfo) -> Result<(), GitError> {
+    async fn create_monorepo_entry(&self, _: CreateEntryInfo) -> Result<(), GitError> {
         return Err(GitError::CustomError(
-            "import dir does not support create file".to_string(),
+            "import dir does not support create entry".to_string(),
         ));
     }
 

--- a/ceres/src/api_service/mod.rs
+++ b/ceres/src/api_service/mod.rs
@@ -22,7 +22,7 @@ use tokio::sync::Mutex;
 
 use crate::model::blame::{BlameQuery, BlameResult};
 use crate::model::git::{
-    CommitBindingInfo, CreateFileInfo, LatestCommitInfo, TreeBriefItem, TreeCommitItem,
+    CommitBindingInfo, CreateEntryInfo, LatestCommitInfo, TreeBriefItem, TreeCommitItem,
     TreeHashItem,
 };
 use common::model::{Pagination, TagInfo};
@@ -48,7 +48,7 @@ impl GitObjectCache {
 pub trait ApiHandler: Send + Sync {
     fn get_context(&self) -> Storage;
 
-    async fn create_monorepo_file(&self, file_info: CreateFileInfo) -> Result<(), GitError>;
+    async fn create_monorepo_entry(&self, file_info: CreateEntryInfo) -> Result<(), GitError>;
 
     async fn get_raw_blob_by_hash(&self, hash: &str) -> Result<Option<raw_blob::Model>, MegaError> {
         let context = self.get_context();

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 
 use crate::api_service::ApiHandler;
 use crate::model::blame::{BlameQuery, BlameResult};
-use crate::model::git::CreateFileInfo;
+use crate::model::git::CreateEntryInfo;
 use crate::model::mr::MrDiffFile;
 use async_trait::async_trait;
 use mercury::errors::GitError;
@@ -52,6 +52,7 @@ use mercury::internal::object::commit::Commit;
 use mercury::internal::object::tree::{Tree, TreeItem, TreeItemMode};
 use neptune::model::diff_model::DiffItem;
 use neptune::neptune_engine::Diff;
+use regex::Regex;
 
 use callisto::sea_orm_active_enums::ConvTypeEnum;
 use callisto::{mega_mr, mega_tag, mega_tree};
@@ -88,78 +89,255 @@ impl ApiHandler for MonoApiService {
     ///
     /// # Arguments
     ///
-    /// * `file_info` - Information about the file or directory to create.
+    /// * `entry_info` - Information about the file or directory to create.
     ///
     /// # Returns
     ///
     /// Returns `Ok(())` on success, or a `GitError` on failure.
-    async fn create_monorepo_file(&self, file_info: CreateFileInfo) -> Result<(), GitError> {
+    async fn create_monorepo_entry(&self, entry_info: CreateEntryInfo) -> Result<(), GitError> {
         let storage = self.storage.mono_storage();
-        let path = PathBuf::from(&file_info.path);
+        let path = PathBuf::from(&entry_info.path);
         let mut save_trees = vec![];
 
-        let mut update_chain = self.search_tree_for_update(&path).await?;
-        let mut target_items = update_chain.pop().unwrap().tree_items.clone();
+        // Try to get the update chain for the given path.
+        // If the path exists, return an empty missing_parts and prefix.
+        // If part of the path does not exist, extract the missing segments (missing_parts),
+        // determine the valid existing prefix, and rebuild the update_chain from that prefix.
+        let (missing_parts, prefix, mut update_chain) =
+            match self.search_tree_for_update(&path).await {
+                Ok(chain) => (Vec::new(), "", chain),
+                Err(err) => {
+                    // If search_tree_for_update failed, try to extract the
+                    // portion of the path that does not exist from the
+                    // error message. The error message is expected to
+                    // contain a substring like: Path '.../missing' not exist
+                    // We capture that substring to determine which segments
+                    // need to be created.
+                    let re: Regex = Regex::new(r"Path '([^']+)' not exist").unwrap();
+                    let extracted = re
+                        .captures(&err.to_string())
+                        .map(|caps| caps[1].to_string())
+                        .unwrap_or(err.to_string());
 
-        // Create a new tree item based on whether it's a directory or file
-        let (new_item, blob) = if file_info.is_directory {
+                    // missing_parts: the trailing path segments after the
+                    // first occurrence of the extracted non-existent path.
+                    // Example: entry_info.path = "a/b/c/d" and extracted = "c/d"
+                    // Then missing_parts = ["c", "d"]
+                    let missing_parts = entry_info
+                        .path
+                        .find(&extracted)
+                        .map(|pos| &entry_info.path[pos..])
+                        .map(|sub| sub.split('/').collect::<Vec<_>>())
+                        .unwrap_or_default();
+
+                    // prefix: the valid existing path before the missing parts.
+                    // Using the same example above, prefix = "a/b/"
+                    let prefix = entry_info
+                        .path
+                        .find(&extracted)
+                        .map(|pos| &entry_info.path[..pos])
+                        .unwrap_or("");
+
+                    // Rebuild the update chain starting from the valid prefix
+                    // so subsequent operations only update from that known
+                    // existing tree downward.
+                    let chain = self.search_tree_for_update(Path::new(prefix)).await?;
+                    (missing_parts, prefix, chain)
+                }
+            };
+
+        let target_items = update_chain.pop().unwrap().tree_items.clone();
+
+        // If there are no missing parts, we are inserting directly into an
+        // existing tree. This branch handles both creating a new file or
+        // creating a new directory in the target tree.
+        if missing_parts.is_empty() {
+            let mut target_items = target_items;
+
+            // Check for duplicate
+            let is_tree_mode = if entry_info.is_directory {
+                TreeItemMode::Tree
+            } else {
+                TreeItemMode::Blob
+            };
             if target_items
                 .iter()
-                .any(|x| x.mode == TreeItemMode::Tree && x.name == file_info.name)
+                .any(|x| x.mode == is_tree_mode && x.name == entry_info.name)
             {
                 return Err(GitError::CustomError("Duplicate name".to_string()));
             }
-            let blob = generate_git_keep_with_timestamp();
-            let tree_item = TreeItem {
-                mode: TreeItemMode::Blob,
-                id: blob.id,
-                name: String::from(".gitkeep"),
-            };
-            let new_dir_tree = Tree::from_tree_items(vec![tree_item]).unwrap();
-            save_trees.push(new_dir_tree.clone());
-            (
-                TreeItem {
-                    mode: TreeItemMode::Tree,
-                    id: new_dir_tree.id,
-                    name: file_info.name.clone(),
-                },
-                blob,
-            )
-        } else {
-            let blob = Blob::from_content(&file_info.content.clone().unwrap());
-            (
-                TreeItem {
+
+            // Create a new tree item based on whether it's a directory or file
+            let (new_item, blob) = if entry_info.is_directory {
+                // For a new directory, create a .gitkeep blob so the
+                // directory can be represented as a tree with at least
+                // one blob entry. The blob contains a timestamp so it's
+                // unique.
+                let blob = generate_git_keep_with_timestamp();
+                let tree_item = TreeItem {
                     mode: TreeItemMode::Blob,
                     id: blob.id,
-                    name: file_info.name.clone(),
+                    name: String::from(".gitkeep"),
+                };
+                let new_dir_tree = Tree::from_tree_items(vec![tree_item]).unwrap();
+                save_trees.push(new_dir_tree.clone());
+                (
+                    TreeItem {
+                        mode: TreeItemMode::Tree,
+                        id: new_dir_tree.id,
+                        name: entry_info.name.clone(),
+                    },
+                    blob,
+                )
+            } else {
+                let blob = Blob::from_content(&entry_info.content.clone().unwrap());
+                (
+                    TreeItem {
+                        mode: TreeItemMode::Blob,
+                        id: blob.id,
+                        name: entry_info.name.clone(),
+                    },
+                    blob,
+                )
+            };
+
+            target_items.push(new_item);
+            target_items.sort_by(|a, b| a.name.cmp(&b.name));
+            let target_tree = Tree::from_tree_items(target_items).unwrap();
+            save_trees.push(target_tree.clone());
+
+            // Build update instructions for parent trees and refs.
+            // build_result_by_chain walks the update_chain (parent trees)
+            // and prepares the list of updated trees and ref updates
+            // that must be applied to persist the change.
+            let update_result = self.build_result_by_chain(
+                if prefix.is_empty() {
+                    path.clone()
+                } else {
+                    PathBuf::from(&prefix)
                 },
-                blob,
-            )
-        };
+                update_chain,
+                target_tree.id,
+            )?;
+            let new_commit_id = self
+                .apply_update_result(&update_result, &entry_info.commit_msg())
+                .await?;
 
-        // Add the new item to the tree items and create a new tree
-        target_items.push(new_item);
-        let target_tree = Tree::from_tree_items(target_items).unwrap();
+            storage.save_mega_blobs(vec![&blob], &new_commit_id).await?;
 
-        // Update the parent tree with the new commit
-        let update_result = self.build_result_by_chain(path, update_chain, target_tree.id)?;
-        save_trees.push(target_tree);
+            let save_trees: Vec<mega_tree::ActiveModel> = save_trees
+                .into_iter()
+                .map(|save_t| {
+                    let mut tree_model: mega_tree::Model = save_t.into();
+                    tree_model.commit_id.clone_from(&new_commit_id);
+                    tree_model.into()
+                })
+                .collect();
+            storage.batch_save_model(save_trees).await?;
+        } else {
+            // If missing_parts is not empty, we must create intermediate
+            // directories (trees) for each missing segment. This branch
+            // constructs the leaf tree first and then wraps it with
+            // additional trees for each missing path component up to the
+            // existing prefix.
+            // Create a new tree item based on whether it's a directory or file
+            let (leaf_item, blob) = if entry_info.is_directory {
+                // Create .gitkeep blob and an initial tree for the new
+                // directory leaf. This represents the directory's own
+                // tree object which will be nested under new parent trees.
+                let blob = generate_git_keep_with_timestamp();
+                let tree_item = TreeItem {
+                    mode: TreeItemMode::Blob,
+                    id: blob.id,
+                    name: String::from(".gitkeep"),
+                };
+                let new_dir_tree = Tree::from_tree_items(vec![tree_item]).unwrap();
+                save_trees.push(new_dir_tree.clone());
+                (
+                    TreeItem {
+                        mode: TreeItemMode::Tree,
+                        id: new_dir_tree.id,
+                        name: entry_info.name.clone(),
+                    },
+                    blob,
+                )
+            } else {
+                let blob = Blob::from_content(&entry_info.content.clone().unwrap());
+                (
+                    TreeItem {
+                        mode: TreeItemMode::Blob,
+                        id: blob.id,
+                        name: entry_info.name.clone(),
+                    },
+                    blob,
+                )
+            };
 
-        let new_commit_id = self
-            .apply_update_result(&update_result, &file_info.commit_msg())
-            .await?;
+            let mut current_tree = Tree::from_tree_items(vec![leaf_item]).unwrap();
+            save_trees.push(current_tree.clone());
 
-        storage.save_mega_blobs(vec![&blob], &new_commit_id).await?;
+            // Wrap the leaf tree with trees for each missing parent segment.
+            // We iterate the missing parts in reverse (from leaf's parent up
+            // to the topmost missing segment) and create a tree object for
+            // each level that points to the previously built child tree.
+            let missing_len = missing_parts.len();
+            for part in missing_parts.iter().rev().take(missing_len - 1) {
+                let sub_item = TreeItem {
+                    mode: TreeItemMode::Tree,
+                    id: current_tree.id,
+                    name: part.to_string(),
+                };
 
-        let save_trees: Vec<mega_tree::ActiveModel> = save_trees
-            .into_iter()
-            .map(|save_t| {
-                let mut tree_model: mega_tree::Model = save_t.into();
-                tree_model.commit_id.clone_from(&new_commit_id);
-                tree_model.into()
-            })
-            .collect();
-        storage.batch_save_model(save_trees).await?;
+                current_tree = Tree::from_tree_items(vec![sub_item]).unwrap();
+                save_trees.push(current_tree.clone());
+            }
+
+            // top_part is the highest-level missing segment (closest to the
+            // existing prefix). We'll insert this as a child into the
+            // existing target_items collected from the update chain.
+            let top_part = missing_parts.first().unwrap().to_string();
+            let top_item = TreeItem {
+                mode: TreeItemMode::Tree,
+                id: current_tree.id,
+                name: top_part.clone(),
+            };
+
+            let mut target_items = target_items;
+
+            // Check for duplicate
+            if target_items
+                .iter()
+                .any(|x| x.mode == TreeItemMode::Tree && x.name == top_part)
+            {
+                return Err(GitError::CustomError("Duplicate name".to_string()));
+            }
+
+            target_items.push(top_item);
+            target_items.sort_by(|a, b| a.name.cmp(&b.name));
+            let target_tree = Tree::from_tree_items(target_items).unwrap();
+            save_trees.push(target_tree.clone());
+
+            // After constructing the nested trees, build update instructions
+            // and apply them to update the parent trees and refs so the
+            // new nested directory/file is persisted in the repository.
+            let update_result =
+                self.build_result_by_chain(PathBuf::from(prefix), update_chain, target_tree.id)?;
+            let new_commit_id = self
+                .apply_update_result(&update_result, &entry_info.commit_msg())
+                .await?;
+
+            storage.save_mega_blobs(vec![&blob], &new_commit_id).await?;
+
+            let save_trees: Vec<mega_tree::ActiveModel> = save_trees
+                .into_iter()
+                .map(|save_t| {
+                    let mut tree_model: mega_tree::Model = save_t.into();
+                    tree_model.commit_id.clone_from(&new_commit_id);
+                    tree_model.into()
+                })
+                .collect();
+            storage.batch_save_model(save_trees).await?;
+        }
 
         Ok(())
     }

--- a/ceres/src/model/git.rs
+++ b/ceres/src/model/git.rs
@@ -9,7 +9,7 @@ use mercury::internal::object::{
 };
 
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateFileInfo {
+pub struct CreateEntryInfo {
     /// can be a file or directory
     pub is_directory: bool,
     pub name: String,
@@ -19,7 +19,7 @@ pub struct CreateFileInfo {
     pub content: Option<String>,
 }
 
-impl CreateFileInfo {
+impl CreateEntryInfo {
     pub fn commit_msg(&self) -> String {
         if self.is_directory {
             format!("\n create new directory {}", self.name)

--- a/mono/src/api/api_router.rs
+++ b/mono/src/api/api_router.rs
@@ -15,7 +15,7 @@ use ceres::{
     api_service::ApiHandler,
     model::blame::{BlameQuery, BlameRequest, BlameResult},
     model::git::{
-        BlobContentQuery, CodePreviewQuery, CreateFileInfo, FileTreeItem, LatestCommitInfo,
+        BlobContentQuery, CodePreviewQuery, CreateEntryInfo, FileTreeItem, LatestCommitInfo,
         TreeCommitItem, TreeHashItem, TreeQuery, TreeResponse,
     },
 };
@@ -32,7 +32,7 @@ use crate::server::http_server::GIT_TAG;
 pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
     OpenApiRouter::new()
         .routes(routes!(life_cycle_check))
-        .routes(routes!(create_file))
+        .routes(routes!(create_entry))
         .routes(routes!(get_latest_commit))
         .routes(routes!(get_tree_commit_info))
         .routes(routes!(get_file_blame))
@@ -91,24 +91,24 @@ async fn life_cycle_check() -> Result<impl IntoResponse, ApiError> {
     Ok(Json("http ready"))
 }
 
-/// Create file in web UI
+/// Create file or folder in web UI
 #[utoipa::path(
     post,
-    path = "/create-file",
-    request_body = CreateFileInfo,
+    path = "/create-entry",
+    request_body = CreateEntryInfo,
     responses(
         (status = 200, body = CommonResult<String>, content_type = "application/json")
     ),
     tag = GIT_TAG
 )]
-async fn create_file(
+async fn create_entry(
     state: State<MonoApiServiceState>,
-    Json(json): Json<CreateFileInfo>,
+    Json(json): Json<CreateEntryInfo>,
 ) -> Result<Json<CommonResult<String>>, ApiError> {
     state
         .api_handler(json.path.as_ref())
         .await?
-        .create_monorepo_file(json.clone())
+        .create_monorepo_entry(json.clone())
         .await?;
     Ok(Json(CommonResult::success(None)))
 }

--- a/moon/apps/web/components/CodeView/NewCodeView/MarkdownEditor.tsx
+++ b/moon/apps/web/components/CodeView/NewCodeView/MarkdownEditor.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import Markdown from 'react-markdown'
+
+import { StarterKit } from '@gitmono/editor/extensions'
+
+interface MarkdownEditorProps {
+  contentState: [string, React.Dispatch<React.SetStateAction<string>>]
+}
+export default function MarkdownEditor({ contentState }: MarkdownEditorProps) {
+  const [content, setContent] = contentState
+  const [lineCount, setLineCount] = useState(1)
+  const [isPreview, setIsPreview] = useState(false)
+
+  const textEditor = useEditor({
+    extensions: StarterKit(),
+    onUpdate: ({ editor }) => {
+      const text = editor.getText().replace(/\n\n/g, '\n')
+
+      setContent(editor.getText())
+      setLineCount(text.split('\n').length || 1)
+    },
+    editorProps: {
+      attributes: {
+        class: 'max-w-full focus:outline-none font-mono text-sm leading-6'
+      }
+    }
+  })
+
+  const lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1)
+
+  return (
+    <div className='flex h-full w-full flex-col rounded-xl border border-[#bec7ce]'>
+      {/* Toggle Bar */}
+      <div className='flex h-14 w-full items-center rounded-t-xl border border-b-[#d0d9e0] bg-[#f9fbfd] p-4'>
+        <div className='inline-flex rounded-md border border-gray-300 bg-white'>
+          <button
+            onClick={() => setIsPreview(false)}
+            className={`rounded-l-md px-4 py-2 text-sm font-medium ${
+              !isPreview ? 'bg-gray-100 text-gray-900' : 'bg-white text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => setIsPreview(true)}
+            className={`rounded-r-md px-4 py-2 text-sm font-medium ${
+              isPreview ? 'bg-gray-100 text-gray-900' : 'bg-white text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Preview
+          </button>
+        </div>
+      </div>
+
+      {/* Content Area */}
+      <div className='flex flex-1 overflow-x-auto'>
+        {isPreview ? (
+          <div className='prose h-full w-full max-w-none overflow-y-auto px-8 pb-4 pt-6'>
+            <Markdown>{content}</Markdown>
+          </div>
+        ) : (
+          <div className='flex w-full font-mono text-sm leading-6'>
+            <div className='select-none rounded-l-xl border-r border-gray-200 bg-gray-50 px-4 text-right text-gray-400'>
+              {lineNumbers.map((n) => (
+                <div key={n}>{n}</div>
+              ))}
+            </div>
+            <div className='flex-1 pl-4'>
+              <EditorContent editor={textEditor} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
+++ b/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+
+import { Button } from '@gitmono/ui/Button'
+import { Dialog } from '@gitmono/ui/Dialog'
+import { Select, SelectTrigger, SelectValue } from '@gitmono/ui/Select'
+
+import { useCreateEntry } from '@/hooks/useCreateEntry'
+
+import MarkdownEditor from './MarkdownEditor'
+import PathInput from './PathInput'
+import toast from 'react-hot-toast'
+
+const NewCodeView = () => {
+  const [path, setPath] = useState('')
+  const [name, setName] = useState('')
+  const [fileType, setFileType] = useState<'folder' | 'file'>('file')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [content, setContent] = useState('')
+  const createEntryHook = useCreateEntry()
+
+  const handlerSubmit = () => {
+    createEntryHook.mutate(
+      {
+        name: name,
+        path: path,
+        is_directory: fileType === 'folder',
+        content: fileType === 'file' ? content : ''
+      },
+      {
+        onSuccess: () => {
+          toast.success('Create Success!')
+          setDialogOpen(false)
+        },
+        onError: (error: any) => {
+          // Try to read a useful message from the error object
+          const msg =
+            error?.message ||
+            (error?.response && error.response.data && error.response.data.message) ||
+            'Create failed. Please try again.'
+
+          toast.error(msg)
+        }
+      }
+    )
+  }
+
+  return (
+    <div className='flex h-full w-full flex-col gap-2'>
+      <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Create folder</Dialog.Title>
+          </Dialog.Header>
+          <Dialog.Content>
+            Creating a folder will clear the current content in the editor, and this action cannot be undone. Do you
+            want to continue?
+          </Dialog.Content>
+          <Dialog.Footer>
+            <Dialog.TrailingActions>
+              <Button variant='flat' onClick={() => setDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handlerSubmit}
+              >
+                Create
+              </Button>
+            </Dialog.TrailingActions>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog.Root>
+      <div className='flex min-h-14 w-full items-center justify-between pl-2 pr-4'>
+        <PathInput pathState={[path, setPath]} nameState={[name, setName]} />
+        <div className='flex gap-2'>
+          <Button
+            onClick={() => {
+              if (fileType === 'folder') {
+                setDialogOpen(true)
+              } else {
+                handlerSubmit()
+              }
+            }}
+          >
+            Create
+          </Button>
+          <Select
+            typeAhead
+            options={[
+              { value: 'folder', label: 'Folder' },
+              { value: 'file', label: 'File' }
+            ]}
+            value={fileType}
+            onChange={(value) => {
+              setFileType(value as 'folder' | 'file')
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder='Select Create Type' />
+            </SelectTrigger>
+          </Select>
+        </div>
+      </div>
+
+      <div className='w-full flex-1 overflow-y-auto'>
+        <MarkdownEditor contentState={[content, setContent]} />
+      </div>
+    </div>
+  )
+}
+
+export default NewCodeView

--- a/moon/apps/web/components/CodeView/NewCodeView/PathInput.tsx
+++ b/moon/apps/web/components/CodeView/NewCodeView/PathInput.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import React, { KeyboardEvent, useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+
+interface PathInputProps {
+  pathState: [string, React.Dispatch<React.SetStateAction<string>>]
+  nameState: [string, React.Dispatch<React.SetStateAction<string>>]
+}
+
+export default function PathInput({ pathState, nameState }: PathInputProps) {
+  const [, setPath] = pathState
+  const [, setName] = nameState
+  const params = useParams()
+
+  const [basePath, setBasePath] = useState<string[]>([])
+
+  const [userSegments, setUserSegments] = useState<string[]>([])
+  const [current, setCurrent] = useState<string>('')
+
+  // update pathState
+  const updatePath = (b: string[], u: string[], c: string) => {
+    const full = [...b, ...u, c].filter(Boolean).join('/')
+
+    setPath(full)
+    setName(c) // Update name when path changes
+  }
+
+  useEffect(() => {
+    const raw = (params as any)?.path
+    let newBase: string[] = []
+
+    if (Array.isArray(raw)) {
+      newBase = raw.filter(Boolean)
+    } else if (typeof raw === 'string') {
+      newBase = raw.split('/').filter(Boolean)
+    }
+    newBase.unshift('')
+
+    setBasePath(newBase)
+    updatePath(newBase, userSegments, current)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((params as any)?.path)])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+
+    if (value.includes('/')) {
+      const rawParts = value.split('/')
+      const parts = rawParts.filter(Boolean)
+      const last = rawParts[rawParts.length - 1] ?? ''
+
+      if (parts.length > 0) {
+        const nextUser = [...userSegments, ...parts]
+
+        setUserSegments(nextUser)
+        setCurrent(last)
+        updatePath(basePath, nextUser, last)
+      } else {
+        setCurrent('')
+        updatePath(basePath, userSegments, '')
+      }
+    } else {
+      setCurrent(value)
+      updatePath(basePath, userSegments, value)
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && current === '') {
+      e.preventDefault()
+      if (userSegments.length > 0) {
+        const nextUser = userSegments.slice(0, -1)
+
+        setUserSegments(nextUser)
+        updatePath(basePath, nextUser, '')
+      } else if (basePath.length > 1) {
+        const nextBase = basePath.slice(0, -1)
+
+        setBasePath(nextBase)
+        updatePath(nextBase, userSegments, '')
+      }
+    }
+  }
+
+  return (
+    <div className='flex max-w-[900px] flex-wrap items-center gap-x-1 gap-y-2 text-gray-700'>
+      {[...basePath, ...userSegments].map((seg, i, arr) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <React.Fragment key={i}>
+          <span className='font-medium text-blue-600'>{seg}</span>
+          {i < arr.length - 1 && <span>/</span>}
+        </React.Fragment>
+      ))}
+      {[...basePath, ...userSegments].length > 0 && <span>/</span>}
+
+      <input
+        type='text'
+        value={current}
+        placeholder='Name your file...'
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className='min-w-[140px] rounded border px-2 py-1 outline-none focus:ring-2 focus:ring-blue-500'
+        aria-label='file-path-input'
+      />
+    </div>
+  )
+}

--- a/moon/apps/web/hooks/useCreateEntry.ts
+++ b/moon/apps/web/hooks/useCreateEntry.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "@/utils/queryClient";
+import { CreateEntryInfo } from "@gitmono/types/generated";
+import { useMutation } from "@tanstack/react-query";
+
+export function useCreateEntry(){
+    return useMutation({
+        mutationFn: (data: CreateEntryInfo) => {
+            return apiClient.v1.postApiCreateEntry().request(data)
+        }
+    });
+}

--- a/moon/apps/web/pages/[org]/code/tree/[...path]/index.tsx
+++ b/moon/apps/web/pages/[org]/code/tree/[...path]/index.tsx
@@ -5,9 +5,12 @@ import { Theme } from '@radix-ui/themes'
 import { useParams } from 'next/navigation'
 
 import { CommonResultVecTreeCommitItem } from '@gitmono/types/generated'
+import { Button } from '@gitmono/ui/Button'
+import { CloseIcon } from '@gitmono/ui/Icons'
 
 import CodeTable from '@/components/CodeView/CodeTable'
 import CommitHistory from '@/components/CodeView/CommitHistory'
+import NewCodeView from '@/components/CodeView/NewCodeView/NewCodeView'
 import BreadCrumb from '@/components/CodeView/TreeView/BreadCrumb'
 import CloneTabs from '@/components/CodeView/TreeView/CloneTabs'
 import RepoTree from '@/components/CodeView/TreeView/RepoTree'
@@ -32,6 +35,8 @@ function TreeDetailPage() {
 
   const reqPath = `${new_path}/README.md`
   const { data: readmeContent } = useGetBlob({ path: reqPath })
+
+  const [isNewCode, setIsNewCode] = useState(false)
 
   const commitInfo = {
     user: {
@@ -63,35 +68,54 @@ function TreeDetailPage() {
     paddingRight: '8px'
   }
 
+  const handleNewClick = () => {
+    setIsNewCode(true)
+  }
+  const handleCloseClick = () => {
+    setIsNewCode(false)
+  }
+
   return (
     <Theme>
       <div className='relative m-4 h-screen'>
-      <div className='h-12 flex justify-between items-center'>
+        <div className='flex min-h-12 items-center justify-between'>
           <BreadCrumb path={path} />
-          {canClone?.data && (
-            <div className='m-1 flex justify-end'>
-              <CloneTabs />
-            </div>
+          {!isNewCode ? (
+            <>
+              <div className='m-1 flex justify-end gap-2'>
+                <Button onClick={handleNewClick}>New</Button>
+                {canClone?.data && <CloneTabs />}
+              </div>
+            </>
+          ) : (
+            <Button onClick={handleCloseClick}>
+              <CloseIcon />
+            </Button>
           )}
         </div>
-        <div className='flex gap-4'>
+        <div className='flex h-full gap-4'>
           <div style={treeStyle}>
             <RepoTree onCommitInfoChange={(path: string) => setNewPath(path)} />
           </div>
-
-          <div style={codeStyle}>
-            {commitInfo && (
-              <div>
-                <CommitHistory flag={'contents'} info={commitInfo} />
-              </div>
-            )}
-            <CodeTable
-              directory={directory}
-              loading={!TreeCommitInfo}
-              onCommitInfoChange={(path: string) => setNewPath(path)}
-              readmeContent={readmeContent?.data}
-            />
-          </div>
+          {!isNewCode ? (
+            <div style={codeStyle}>
+              {commitInfo && (
+                <div>
+                  <CommitHistory flag={'contents'} info={commitInfo} />
+                </div>
+              )}
+              <CodeTable
+                directory={directory}
+                loading={!TreeCommitInfo}
+                onCommitInfoChange={(path: string) => setNewPath(path)}
+                readmeContent={readmeContent?.data}
+              />
+            </div>
+          ) : (
+            <div className='pb-18 flex-1 overflow-hidden'>
+              <NewCodeView />
+            </div>
+          )}
         </div>
       </div>
     </Theme>


### PR DESCRIPTION
## 概述

本 PR 实现了通过 UI 创建多级目录或文件的完整功能，并提供了对应的后端 API 接口。

## 变更内容

- **UI 部分**：
  - 新增 `PathInput` 组件，支持输入层级路径（例如 `folder/subfolder/file.txt`）
  - 重构 `NewCodeView`，集成路径输入与文件/目录创建逻辑
  - 调整 `MarkdownEditor` 以适配新的创建流程
- **后端部分**：
  - 新增 API 接口，支持递归创建目录和文件

## 破坏性变更（Breaking Changes）

- 后端接口 `create_file` 已重命名为 `create_entry`，以更准确地反映其支持创建文件和目录的双重能力。  
  请前端调用方同步更新接口名称。


## 相关工作
#1424 