### PR TITLE
fix(UI): correct frontend call to create-entry API

### DIFF
--- a/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
+++ b/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import toast from 'react-hot-toast'
 
 import { Button } from '@gitmono/ui/Button'
 import { Dialog } from '@gitmono/ui/Dialog'
@@ -8,7 +9,6 @@ import { useCreateEntry } from '@/hooks/useCreateEntry'
 
 import MarkdownEditor from './MarkdownEditor'
 import PathInput from './PathInput'
-import toast from 'react-hot-toast'
 
 const NewCodeView = () => {
   const [path, setPath] = useState('')
@@ -22,7 +22,7 @@ const NewCodeView = () => {
     createEntryHook.mutate(
       {
         name: name,
-        path: path,
+        path: '/' + path.replace('/'+name, ''),
         is_directory: fileType === 'folder',
         content: fileType === 'file' ? content : ''
       },
@@ -60,11 +60,7 @@ const NewCodeView = () => {
               <Button variant='flat' onClick={() => setDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button
-                onClick={handlerSubmit}
-              >
-                Create
-              </Button>
+              <Button onClick={handlerSubmit}>Create</Button>
             </Dialog.TrailingActions>
           </Dialog.Footer>
         </Dialog.Content>
@@ -73,6 +69,7 @@ const NewCodeView = () => {
         <PathInput pathState={[path, setPath]} nameState={[name, setName]} />
         <div className='flex gap-2'>
           <Button
+            disabled={name === ''}
             onClick={() => {
               if (fileType === 'folder') {
                 setDialogOpen(true)

--- a/moon/apps/web/hooks/useCreateEntry.ts
+++ b/moon/apps/web/hooks/useCreateEntry.ts
@@ -1,11 +1,11 @@
-import { apiClient } from "@/utils/queryClient";
+import { legacyApiClient } from "@/utils/queryClient";
 import { CreateEntryInfo } from "@gitmono/types/generated";
 import { useMutation } from "@tanstack/react-query";
 
 export function useCreateEntry(){
     return useMutation({
         mutationFn: (data: CreateEntryInfo) => {
-            return apiClient.v1.postApiCreateEntry().request(data)
+            return legacyApiClient.v1.postApiCreateEntry().request(data)
         }
     });
 }


### PR DESCRIPTION
##  PR 描述

### 背景
前端在调用 `create-entry` 接口时存在问题，导致请求404，无法正常创建 entry。

### 修改内容
- 修复了前端调用 `create-entry` 接口的域名
- 调整了请求参数结构，使其与后端 API 定义保持一致  

### 测试验证
- 本地验证调用接口成功返回，能够正确创建 entry  

### 影响范围
- 仅影响前端调用 `create-entry` 接口的逻辑  
- 其他功能不受影响
