### PR TITLE
[mono]FIX: auth logic for review resolve

### DIFF
--- a/jupiter/src/storage/conversation_storage.rs
+++ b/jupiter/src/storage/conversation_storage.rs
@@ -111,13 +111,11 @@ impl ConversationStorage {
         &self,
         mr_link: &str,
         review_id: &i64,
-        username: &str,
         state: bool,
     ) -> Result<(), MegaError> {
         let mut conversation = mega_conversation::Entity::find()
             .filter(mega_conversation::Column::Id.eq(*review_id))
             .filter(mega_conversation::Column::ConvType.eq(ConvTypeEnum::Review))
-            .filter(mega_conversation::Column::Username.eq(username))
             .filter(mega_conversation::Column::Link.eq(mr_link))
             .one(self.get_connection())
             .await

--- a/jupiter/src/storage/mr_storage.rs
+++ b/jupiter/src/storage/mr_storage.rs
@@ -178,14 +178,14 @@ impl MrStorage {
 
     pub async fn is_assignee(&self, link: &str, username: &str) -> Result<(), MegaError> {
         let assignee = mega_mr::Entity::find()
-            .filter(mega_mr::Column::Link.eq(link)) 
+            .filter(mega_mr::Column::Link.eq(link))
             .find_with_related(item_assignees::Entity)
             .filter(item_assignees::Column::ItemId.eq(username))
             .all(self.get_connection())
             .await?;
         if assignee.is_empty() {
             return Err(MegaError::with_message("Not an assignee"));
-        } 
+        }
 
         Ok(())
     }

--- a/jupiter/src/storage/mr_storage.rs
+++ b/jupiter/src/storage/mr_storage.rs
@@ -176,6 +176,20 @@ impl MrStorage {
         Ok(assignees.first().cloned())
     }
 
+    pub async fn is_assignee(&self, link: &str, username: &str) -> Result<(), MegaError> {
+        let assignee = mega_mr::Entity::find()
+            .filter(mega_mr::Column::Link.eq(link)) 
+            .find_with_related(item_assignees::Entity)
+            .filter(item_assignees::Column::ItemId.eq(username))
+            .all(self.get_connection())
+            .await?;
+        if assignee.is_empty() {
+            return Err(MegaError::with_message("Not an assignee"));
+        } 
+
+        Ok(())
+    }
+
     pub async fn new_mr(
         &self,
         path: &str,

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -637,16 +637,12 @@ async fn review_resolve(
         .storage
         .mr_storage()
         .is_assignee(&link, &user.username)
-        .await?; 
+        .await?;
 
     state
         .storage
         .conversation_storage()
-        .change_review_state(
-            &link,
-            &payload.conversation_id,
-            payload.resolved,
-        )
+        .change_review_state(&link, &payload.conversation_id, payload.resolved)
         .await?;
 
     Ok(Json(CommonResult::success(None)))

--- a/mono/src/api/mr/mr_router.rs
+++ b/mono/src/api/mr/mr_router.rs
@@ -635,11 +635,16 @@ async fn review_resolve(
 ) -> Result<Json<CommonResult<String>>, ApiError> {
     state
         .storage
+        .mr_storage()
+        .is_assignee(&link, &user.username)
+        .await?; 
+
+    state
+        .storage
         .conversation_storage()
         .change_review_state(
             &link,
             &payload.conversation_id,
-            &user.campsite_user_id,
             payload.resolved,
         )
         .await?;


### PR DESCRIPTION
Fix user auth logic when calling the mr review resolve api
The fixed logic checks whether a user is an assignee of the mr