### PR TITLE
Add bot token storage, audit logging, and HTTP APIs for bot token management

### DIFF
--- a/ceres/src/api_service/bot_ops.rs
+++ b/ceres/src/api_service/bot_ops.rs
@@ -1,0 +1,73 @@
+use callisto::sea_orm_active_enums::{
+    InstallationBotStatusEnum, PermissionEnum, PermissionScopeEnum,
+};
+use common::errors::MegaError;
+
+use crate::api_service::mono_api_service::MonoApiService;
+
+impl MonoApiService {
+    /// Check whether a bot has sufficient permission on a given resource.
+    ///
+    /// The decision is based on:
+    /// - Bot status (must be enabled).
+    /// - Whether the bot has at least one enabled installation record.
+    /// - The bot-level `permission_scope` compared against `required_permission`.
+    ///
+    /// Installation scope is currently checked in an aggregated way (any enabled installation
+    /// is sufficient) and can be refined later to be resource-type aware.
+    pub async fn check_bot_permission(
+        &self,
+        bot_id: i64,
+        _resource_type: callisto::sea_orm_active_enums::ResourceTypeEnum,
+        _resource_id: &str,
+        required_permission: PermissionEnum,
+    ) -> Result<bool, MegaError> {
+        let bots_storage = self.storage.bots_storage();
+
+        // 1. Load bot and ensure it is enabled.
+        let bot = match bots_storage.get_bot_by_id(bot_id).await? {
+            Some(b) => b,
+            None => return Ok(false),
+        };
+
+        if bot.status != callisto::sea_orm_active_enums::BotStatusEnum::Enabled {
+            return Ok(false);
+        }
+
+        // 2. Ensure the bot has at least one enabled installation.
+        let installations = bots_storage.get_installed_bot_by_id(bot_id).await?;
+        let has_enabled_installation = installations
+            .iter()
+            .any(|inst| inst.status == InstallationBotStatusEnum::Enabled);
+
+        if !has_enabled_installation {
+            return Ok(false);
+        }
+
+        // 3. Compare bot-level permission scope with the required permission.
+        Ok(scope_satisfies_permission(
+            &bot.permission_scope,
+            &required_permission,
+        ))
+    }
+}
+
+fn scope_level(scope: &PermissionScopeEnum) -> u8 {
+    match scope {
+        PermissionScopeEnum::Read => 1,
+        PermissionScopeEnum::Write => 2,
+        PermissionScopeEnum::Admin => 3,
+    }
+}
+
+fn permission_level(permission: &PermissionEnum) -> u8 {
+    match permission {
+        PermissionEnum::Read => 1,
+        PermissionEnum::Write => 2,
+        PermissionEnum::Admin => 3,
+    }
+}
+
+fn scope_satisfies_permission(scope: &PermissionScopeEnum, required: &PermissionEnum) -> bool {
+    scope_level(scope) >= permission_level(required)
+}

--- a/ceres/src/api_service/mod.rs
+++ b/ceres/src/api_service/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 pub mod admin_ops;
 pub mod blame_ops;
 pub mod blob_ops;
+pub mod bot_ops;
 pub mod buck_tree_builder;
 pub mod cache;
 pub mod commit_ops;

--- a/jupiter/src/migration/m20260316_120000_add_bot_tokens_token_hash_index.rs
+++ b/jupiter/src/migration/m20260316_120000_add_bot_tokens_token_hash_index.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_bot_tokens_token_hash")
+                    .table(BotTokens::Table)
+                    .col(BotTokens::TokenHash)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_bot_tokens_token_hash")
+                    .table(BotTokens::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum BotTokens {
+    Table,
+    TokenHash,
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -94,6 +94,7 @@ mod m20260306_121829_create_bots_related_table;
 mod m20260308_191753_create_webhook;
 mod m20260308_220000_add_base_branch_to_mega_cl;
 mod m20260308_230000_normalize_webhook_event_types;
+mod m20260316_120000_add_bot_tokens_token_hash_index;
 
 /// Creates a primary key column definition with big integer type.
 ///
@@ -178,6 +179,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260308_191753_create_webhook::Migration),
             Box::new(m20260308_220000_add_base_branch_to_mega_cl::Migration),
             Box::new(m20260308_230000_normalize_webhook_event_types::Migration),
+            Box::new(m20260316_120000_add_bot_tokens_token_hash_index::Migration),
         ]
     }
 }

--- a/jupiter/src/model/bot_token_dto.rs
+++ b/jupiter/src/model/bot_token_dto.rs
@@ -1,0 +1,11 @@
+use sea_orm::prelude::DateTimeWithTimeZone;
+
+#[derive(Debug, Clone)]
+pub struct BotTokenInfo {
+    pub id: i64,
+    pub token_name: String,
+    pub expires_at: Option<DateTimeWithTimeZone>,
+    pub revoked: bool,
+    pub created_at: DateTimeWithTimeZone,
+}
+

--- a/jupiter/src/model/bot_token_dto.rs
+++ b/jupiter/src/model/bot_token_dto.rs
@@ -8,4 +8,3 @@ pub struct BotTokenInfo {
     pub revoked: bool,
     pub created_at: DateTimeWithTimeZone,
 }
-

--- a/jupiter/src/model/mod.rs
+++ b/jupiter/src/model/mod.rs
@@ -1,3 +1,4 @@
+pub mod bot_token_dto;
 pub mod cl_dto;
 pub mod code_review_dto;
 pub mod common;

--- a/jupiter/src/storage/audit_storage.rs
+++ b/jupiter/src/storage/audit_storage.rs
@@ -1,0 +1,55 @@
+use std::ops::Deref;
+
+use callisto::{
+    audit_logs,
+    sea_orm_active_enums::{ActorTypeEnum, AuditActionEnum, TargetTypeEnum},
+};
+use chrono::Utc;
+use common::errors::MegaError;
+use idgenerator::IdInstance;
+use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+
+use crate::storage::base_storage::{BaseStorage, StorageConnector};
+
+#[derive(Clone)]
+pub struct AuditStorage {
+    pub base: BaseStorage,
+}
+
+impl Deref for AuditStorage {
+    type Target = BaseStorage;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl AuditStorage {
+    /// Write an audit log entry for a given actor and target.
+    ///
+    /// `metadata` is stored as JSON for flexible, structured details per action.
+    pub async fn log_audit(
+        &self,
+        actor_id: i64,
+        actor_type: ActorTypeEnum,
+        action: AuditActionEnum,
+        target_type: TargetTypeEnum,
+        target_id: i64,
+        metadata: Option<serde_json::Value>,
+    ) -> Result<audit_logs::Model, MegaError> {
+        let model = audit_logs::ActiveModel {
+            id: Set(IdInstance::next_id()),
+            actor_id: Set(actor_id),
+            actor_type: Set(actor_type),
+            action: Set(action),
+            target_type: Set(target_type),
+            target_id: Set(target_id),
+            metadata: Set(metadata.map(Into::into)),
+            created_at: Set(Utc::now()),
+        };
+
+        let inserted = model.insert(self.get_connection()).await?;
+        Ok(inserted)
+    }
+}
+

--- a/jupiter/src/storage/audit_storage.rs
+++ b/jupiter/src/storage/audit_storage.rs
@@ -52,4 +52,3 @@ impl AuditStorage {
         Ok(inserted)
     }
 }
-

--- a/jupiter/src/storage/audit_storage.rs
+++ b/jupiter/src/storage/audit_storage.rs
@@ -7,7 +7,7 @@ use callisto::{
 use chrono::Utc;
 use common::errors::MegaError;
 use idgenerator::IdInstance;
-use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, prelude::DateTimeWithTimeZone};
 
 use crate::storage::base_storage::{BaseStorage, StorageConnector};
 
@@ -37,6 +37,7 @@ impl AuditStorage {
         target_id: i64,
         metadata: Option<serde_json::Value>,
     ) -> Result<audit_logs::Model, MegaError> {
+        let created_at: DateTimeWithTimeZone = Utc::now().into();
         let model = audit_logs::ActiveModel {
             id: Set(IdInstance::next_id()),
             actor_id: Set(actor_id),
@@ -45,7 +46,7 @@ impl AuditStorage {
             target_type: Set(target_type),
             target_id: Set(target_id),
             metadata: Set(metadata.map(Into::into)),
-            created_at: Set(Utc::now()),
+            created_at: Set(created_at),
         };
 
         let inserted = model.insert(self.get_connection()).await?;

--- a/jupiter/src/storage/audit_storage.rs
+++ b/jupiter/src/storage/audit_storage.rs
@@ -45,7 +45,7 @@ impl AuditStorage {
             action: Set(action),
             target_type: Set(target_type),
             target_id: Set(target_id),
-            metadata: Set(metadata.map(Into::into)),
+            metadata: Set(metadata),
             created_at: Set(created_at),
         };
 

--- a/jupiter/src/storage/bots_storage.rs
+++ b/jupiter/src/storage/bots_storage.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use callisto::{
     bot_keys, bot_tokens, bots,
     sea_orm_active_enums::{BotStatusEnum, PermissionScopeEnum},
@@ -10,21 +10,14 @@ use common::errors::MegaError;
 use hmac::{Hmac, Mac};
 use idgenerator::IdInstance;
 use rsa::{
+    RsaPrivateKey,
     pkcs8::{EncodePrivateKey, EncodePublicKey},
     rand_core::OsRng,
-    RsaPrivateKey,
 };
 use sea_orm::{
-    ActiveModelTrait,
-    ActiveValue::Set,
-    ColumnTrait,
-    EntityTrait,
-    IntoActiveModel,
-    QueryFilter,
-    QueryOrder,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, EntityTrait, IntoActiveModel,
+    QueryFilter, QueryOrder, prelude::DateTimeWithTimeZone,
 };
-use sea_orm::prelude::DateTimeWithTimeZone;
-use sea_orm::Condition;
 use sha2::Sha256;
 
 use crate::{
@@ -278,11 +271,7 @@ impl BotsStorage {
     }
 
     /// Revoke a single token for a bot. Idempotent.
-    pub async fn revoke_bot_token(
-        &self,
-        bot_id: i64,
-        token_id: i64,
-    ) -> Result<(), MegaError> {
+    pub async fn revoke_bot_token(&self, bot_id: i64, token_id: i64) -> Result<(), MegaError> {
         let conn = self.get_connection();
 
         if let Some(model) = bot_tokens::Entity::find_by_id(token_id)
@@ -357,9 +346,7 @@ impl BotsStorage {
             return Ok(None);
         };
 
-        let bot = bots::Entity::find_by_id(token.bot_id)
-            .one(conn)
-            .await?;
+        let bot = bots::Entity::find_by_id(token.bot_id).one(conn).await?;
 
         let Some(bot) = bot else {
             return Ok(None);
@@ -394,9 +381,7 @@ fn load_bot_token_hmac_key() -> Result<Vec<u8>, MegaError> {
 }
 
 fn compute_bot_token_hash(token_body: &str, key: &[u8]) -> String {
-    let mut mac =
-        HmacSha256::new_from_slice(key).expect("HMAC-SHA256 can take a key of any size");
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 can take a key of any size");
     mac.update(token_body.as_bytes());
     hex::encode(mac.finalize().into_bytes())
 }
-

--- a/jupiter/src/storage/bots_storage.rs
+++ b/jupiter/src/storage/bots_storage.rs
@@ -15,8 +15,10 @@ use rsa::{
     rand_core::OsRng,
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, EntityTrait, IntoActiveModel,
-    QueryFilter, QueryOrder, prelude::DateTimeWithTimeZone,
+    ActiveModelTrait,
+    ActiveValue::Set,
+    ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder,
+    prelude::{DateTimeWithTimeZone, Expr},
 };
 use sha2::Sha256;
 
@@ -222,6 +224,13 @@ impl BotsStorage {
         Ok(res)
     }
 
+    /// Get a bot by ID. Returns None if the bot does not exist.
+    pub async fn get_bot_by_id(&self, bot_id: i64) -> Result<Option<bots::Model>, MegaError> {
+        Ok(bots::Entity::find_by_id(bot_id)
+            .one(self.get_connection())
+            .await?)
+    }
+
     /// Generate a new bot token, persist its HMAC-SHA256 hash and return the model with plaintext.
     pub async fn generate_bot_token(
         &self,
@@ -290,25 +299,12 @@ impl BotsStorage {
     /// Revoke all tokens belonging to the given bot. Idempotent.
     pub async fn revoke_bot_tokens_by_bot(&self, bot_id: i64) -> Result<(), MegaError> {
         let conn = self.get_connection();
-
-        let models = bot_tokens::Entity::find()
+        bot_tokens::Entity::update_many()
+            .col_expr(bot_tokens::Column::Revoked, Expr::value(true))
             .filter(bot_tokens::Column::BotId.eq(bot_id))
-            .all(conn)
+            .filter(bot_tokens::Column::Revoked.eq(false))
+            .exec(conn)
             .await?;
-
-        if models.is_empty() {
-            return Ok(());
-        }
-
-        for model in models {
-            if model.revoked {
-                continue;
-            }
-            let mut active: bot_tokens::ActiveModel = model.into_active_model();
-            active.revoked = Set(true);
-            let _ = active.update(conn).await?;
-        }
-
         Ok(())
     }
 
@@ -327,7 +323,7 @@ impl BotsStorage {
         };
         let token_hash = compute_bot_token_hash(token_body, &hmac_key);
 
-        let now = Utc::now();
+        let now: DateTimeWithTimeZone = Utc::now().into();
 
         let conn = self.get_connection();
 
@@ -371,13 +367,27 @@ fn generate_bot_token_plain() -> Result<String, MegaError> {
     Ok(format!("{BOT_TOKEN_PREFIX}{encoded}"))
 }
 
+const BOT_TOKEN_HMAC_MIN_LEN: usize = 32;
+
 fn load_bot_token_hmac_key() -> Result<Vec<u8>, MegaError> {
     let secret = std::env::var(BOT_TOKEN_HMAC_KEY_ENV).map_err(|_| {
         MegaError::Other(format!(
             "{BOT_TOKEN_HMAC_KEY_ENV} is not set for bot token HMAC"
         ))
     })?;
-    Ok(secret.into_bytes())
+    let trimmed = secret.trim();
+    if trimmed.is_empty() {
+        return Err(MegaError::Other(format!(
+            "{BOT_TOKEN_HMAC_KEY_ENV} must not be empty for bot token HMAC"
+        )));
+    }
+    if trimmed.len() < BOT_TOKEN_HMAC_MIN_LEN {
+        return Err(MegaError::Other(format!(
+            "{BOT_TOKEN_HMAC_KEY_ENV} is too short for bot token HMAC; it must be at least {} characters long",
+            BOT_TOKEN_HMAC_MIN_LEN
+        )));
+    }
+    Ok(trimmed.as_bytes().to_vec())
 }
 
 fn compute_bot_token_hash(token_body: &str, key: &[u8]) -> String {

--- a/jupiter/src/storage/bots_storage.rs
+++ b/jupiter/src/storage/bots_storage.rs
@@ -1,22 +1,40 @@
 use std::ops::Deref;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use callisto::{
-    bot_installations, bot_keys, bots,
-    sea_orm_active_enums::{
-        BotStatusEnum, InstallationBotStatusEnum, InstallationTargetTypeEnum, PermissionScopeEnum,
-    },
+    bot_keys, bot_tokens, bots,
+    sea_orm_active_enums::{BotStatusEnum, PermissionScopeEnum},
 };
+use chrono::Utc;
 use common::errors::MegaError;
+use hmac::{Hmac, Mac};
+use idgenerator::IdInstance;
 use rsa::{
-    RsaPrivateKey,
     pkcs8::{EncodePrivateKey, EncodePublicKey},
     rand_core::OsRng,
+    RsaPrivateKey,
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    ActiveModelTrait,
+    ActiveValue::Set,
+    ColumnTrait,
+    EntityTrait,
+    IntoActiveModel,
+    QueryFilter,
+    QueryOrder,
+};
+use sea_orm::prelude::DateTimeWithTimeZone;
+use sea_orm::Condition;
+use sha2::Sha256;
+
+use crate::{
+    model::bot_token_dto::BotTokenInfo,
+    storage::base_storage::{BaseStorage, StorageConnector},
 };
 
-use crate::storage::base_storage::{BaseStorage, StorageConnector};
+const BOT_TOKEN_PREFIX: &str = "bot_";
+const BOT_TOKEN_RANDOM_LEN: usize = 32;
+const BOT_TOKEN_HMAC_KEY_ENV: &str = "MEGA_BOT_TOKEN_HMAC_SECRET";
 
 #[derive(Clone)]
 pub struct BotsStorage {
@@ -210,4 +228,175 @@ impl BotsStorage {
 
         Ok(res)
     }
+
+    /// Generate a new bot token, persist its HMAC-SHA256 hash and return the model with plaintext.
+    pub async fn generate_bot_token(
+        &self,
+        bot_id: i64,
+        token_name: &str,
+        expires_at: Option<DateTimeWithTimeZone>,
+    ) -> Result<(bot_tokens::Model, String), MegaError> {
+        let token_plain = generate_bot_token_plain()?;
+        let token_body = token_plain
+            .strip_prefix(BOT_TOKEN_PREFIX)
+            .unwrap_or(&token_plain);
+
+        let hmac_key = load_bot_token_hmac_key()?;
+        let token_hash = compute_bot_token_hash(token_body, &hmac_key);
+
+        let active = bot_tokens::ActiveModel {
+            id: Set(IdInstance::next_id()),
+            bot_id: Set(bot_id),
+            token_hash: Set(token_hash),
+            token_name: Set(token_name.to_owned()),
+            expires_at: Set(expires_at),
+            ..Default::default()
+        };
+
+        let model = active.insert(self.get_connection()).await?;
+        Ok((model, token_plain))
+    }
+
+    /// List tokens for a given bot, ordered by creation time descending.
+    pub async fn list_bot_tokens(&self, bot_id: i64) -> Result<Vec<BotTokenInfo>, MegaError> {
+        let models = bot_tokens::Entity::find()
+            .filter(bot_tokens::Column::BotId.eq(bot_id))
+            .order_by_desc(bot_tokens::Column::CreatedAt)
+            .all(self.get_connection())
+            .await?;
+
+        Ok(models
+            .into_iter()
+            .map(|m| BotTokenInfo {
+                id: m.id,
+                token_name: m.token_name,
+                expires_at: m.expires_at,
+                revoked: m.revoked,
+                created_at: m.created_at,
+            })
+            .collect())
+    }
+
+    /// Revoke a single token for a bot. Idempotent.
+    pub async fn revoke_bot_token(
+        &self,
+        bot_id: i64,
+        token_id: i64,
+    ) -> Result<(), MegaError> {
+        let conn = self.get_connection();
+
+        if let Some(model) = bot_tokens::Entity::find_by_id(token_id)
+            .filter(bot_tokens::Column::BotId.eq(bot_id))
+            .one(conn)
+            .await?
+        {
+            let mut active: bot_tokens::ActiveModel = model.into_active_model();
+            active.revoked = Set(true);
+            let _ = active.update(conn).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Revoke all tokens belonging to the given bot. Idempotent.
+    pub async fn revoke_bot_tokens_by_bot(&self, bot_id: i64) -> Result<(), MegaError> {
+        let conn = self.get_connection();
+
+        let models = bot_tokens::Entity::find()
+            .filter(bot_tokens::Column::BotId.eq(bot_id))
+            .all(conn)
+            .await?;
+
+        if models.is_empty() {
+            return Ok(());
+        }
+
+        for model in models {
+            if model.revoked {
+                continue;
+            }
+            let mut active: bot_tokens::ActiveModel = model.into_active_model();
+            active.revoked = Set(true);
+            let _ = active.update(conn).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Find bot and token by plaintext token string (with or without `bot_` prefix).
+    pub async fn find_bot_by_token(
+        &self,
+        token_plain: &str,
+    ) -> Result<Option<(bots::Model, bot_tokens::Model)>, MegaError> {
+        let token_body = token_plain
+            .strip_prefix(BOT_TOKEN_PREFIX)
+            .unwrap_or(token_plain);
+
+        let hmac_key = match load_bot_token_hmac_key() {
+            Ok(key) => key,
+            Err(e) => return Err(e),
+        };
+        let token_hash = compute_bot_token_hash(token_body, &hmac_key);
+
+        let now = Utc::now();
+
+        let conn = self.get_connection();
+
+        let token = bot_tokens::Entity::find()
+            .filter(bot_tokens::Column::TokenHash.eq(token_hash))
+            .filter(bot_tokens::Column::Revoked.eq(false))
+            .filter(
+                Condition::any()
+                    .add(bot_tokens::Column::ExpiresAt.is_null())
+                    .add(bot_tokens::Column::ExpiresAt.gt(now)),
+            )
+            .one(conn)
+            .await?;
+
+        let Some(token) = token else {
+            return Ok(None);
+        };
+
+        let bot = bots::Entity::find_by_id(token.bot_id)
+            .one(conn)
+            .await?;
+
+        let Some(bot) = bot else {
+            return Ok(None);
+        };
+
+        Ok(Some((bot, token)))
+    }
 }
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn generate_bot_token_plain() -> Result<String, MegaError> {
+    use ring::rand::{SecureRandom, SystemRandom};
+
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; BOT_TOKEN_RANDOM_LEN];
+    rng.fill(&mut bytes).map_err(|_| {
+        MegaError::Other("failed to generate secure random bytes for bot token".to_string())
+    })?;
+
+    let encoded = BASE64_STANDARD.encode(bytes);
+    Ok(format!("{BOT_TOKEN_PREFIX}{encoded}"))
+}
+
+fn load_bot_token_hmac_key() -> Result<Vec<u8>, MegaError> {
+    let secret = std::env::var(BOT_TOKEN_HMAC_KEY_ENV).map_err(|_| {
+        MegaError::Other(format!(
+            "{BOT_TOKEN_HMAC_KEY_ENV} is not set for bot token HMAC"
+        ))
+    })?;
+    Ok(secret.into_bytes())
+}
+
+fn compute_bot_token_hash(token_body: &str, key: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(key).expect("HMAC-SHA256 can take a key of any size");
+    mac.update(token_body.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+

--- a/jupiter/src/storage/bots_storage.rs
+++ b/jupiter/src/storage/bots_storage.rs
@@ -2,8 +2,10 @@ use std::ops::Deref;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use callisto::{
-    bot_keys, bot_tokens, bots,
-    sea_orm_active_enums::{BotStatusEnum, PermissionScopeEnum},
+    bot_installations, bot_keys, bot_tokens, bots,
+    sea_orm_active_enums::{
+        BotStatusEnum, InstallationBotStatusEnum, InstallationTargetTypeEnum, PermissionScopeEnum,
+    },
 };
 use chrono::Utc;
 use common::errors::MegaError;
@@ -111,14 +113,14 @@ impl BotsStorage {
         installed_by: i64,
     ) -> Result<bot_installations::Model, MegaError> {
         // Check if already installed
-        if (bot_installations::Entity::find()
+        let existing: Option<bot_installations::Model> = bot_installations::Entity::find()
             .filter(bot_installations::Column::BotId.eq(bot_id))
             .filter(bot_installations::Column::TargetType.eq(target_type.clone()))
             .filter(bot_installations::Column::TargetId.eq(target_id))
             .one(self.get_connection())
-            .await?)
-            .is_some()
-        {
+            .await?;
+
+        if existing.is_some() {
             return Err(MegaError::Other(
                 "Bot already installed on this target".into(),
             ));
@@ -152,13 +154,11 @@ impl BotsStorage {
             .filter(bot_installations::Column::TargetId.eq(target_id))
             .one(self.get_connection())
             .await?
-            .ok_or_else(|| MegaError::Other("Bot installation not found".into()))?
-            .into_active_model();
+            .ok_or_else(|| MegaError::Other("Bot installation not found".into()))?;
 
-        installation
-            .into_active_model()
-            .delete(self.get_connection())
-            .await?;
+        let active: bot_installations::ActiveModel = installation.into_active_model();
+
+        active.delete(self.get_connection()).await?;
 
         Ok(())
     }
@@ -171,7 +171,7 @@ impl BotsStorage {
         target_id: i64,
         status: InstallationBotStatusEnum,
     ) -> Result<bot_installations::Model, MegaError> {
-        let mut installation = bot_installations::Entity::find()
+        let mut installation: bot_installations::ActiveModel = bot_installations::Entity::find()
             .filter(bot_installations::Column::BotId.eq(bot_id))
             .filter(bot_installations::Column::TargetType.eq(target_type.clone()))
             .filter(bot_installations::Column::TargetId.eq(target_id))

--- a/jupiter/src/storage/mod.rs
+++ b/jupiter/src/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_storage;
 pub mod base_storage;
 pub mod bots_storage;
 pub mod buck_storage;
@@ -39,6 +40,7 @@ use crate::{
         webhook_service::WebhookService,
     },
     storage::{
+        audit_storage::AuditStorage,
         base_storage::{BaseStorage, StorageConnector},
         bots_storage::BotsStorage,
         buck_storage::BuckStorage,
@@ -90,6 +92,7 @@ pub struct AppService {
     pub build_trigger_storage: BuildTriggerStorage,
     pub bots_storage: BotsStorage,
     pub webhook_storage: WebhookStorage,
+    pub audit_storage: AuditStorage,
 }
 
 impl AppService {
@@ -121,6 +124,7 @@ impl AppService {
             build_trigger_storage: BuildTriggerStorage { base: mock.clone() },
             bots_storage: BotsStorage { base: mock.clone() },
             webhook_storage: WebhookStorage { base: mock.clone() },
+            audit_storage: AuditStorage { base: mock.clone() },
         })
     }
 }
@@ -184,6 +188,7 @@ impl Storage {
         let build_trigger_storage = BuildTriggerStorage { base: base.clone() };
         let bots_storage = BotsStorage { base: base.clone() };
         let webhook_storage = WebhookStorage { base: base.clone() };
+        let audit_storage = AuditStorage { base: base.clone() };
 
         let git_service = GitService {
             obj_storage: ObjectStorageFactory::build(
@@ -244,6 +249,7 @@ impl Storage {
             build_trigger_storage,
             bots_storage,
             webhook_storage: webhook_storage.clone(),
+            audit_storage,
         };
         let merge_queue_service = MergeQueueService::new(base.clone());
         let buck_service = BuckService::new(
@@ -430,6 +436,10 @@ impl Storage {
 
     pub fn webhook_storage(&self) -> WebhookStorage {
         self.app_service.webhook_storage.clone()
+    }
+
+    pub fn audit_storage(&self) -> AuditStorage {
+        self.app_service.audit_storage.clone()
     }
 
     pub fn bots_storage(&self) -> BotsStorage {

--- a/jupiter/src/tests.rs
+++ b/jupiter/src/tests.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     storage::{
         AppService, Storage,
+        audit_storage::AuditStorage,
         base_storage::{BaseStorage, StorageConnector},
         bots_storage::BotsStorage,
         buck_storage::BuckStorage,
@@ -89,6 +90,7 @@ pub async fn test_storage(temp_dir: impl AsRef<Path>) -> Storage {
         build_trigger_storage: BuildTriggerStorage { base: base.clone() },
         bots_storage: BotsStorage { base: base.clone() },
         webhook_storage: WebhookStorage { base: base.clone() },
+        audit_storage: AuditStorage { base: base.clone() },
     };
 
     apply_migrations(&connection, true).await.unwrap();

--- a/mono/src/api/guard/cedar_guard.rs
+++ b/mono/src/api/guard/cedar_guard.rs
@@ -11,7 +11,11 @@ use http::StatusCode;
 use once_cell::sync::Lazy;
 use saturn::{ActionEnum, context::CedarContext, entitystore::EntityStore, util::SaturnEUid};
 
-use crate::api::{MonoApiServiceState, error::ApiError, oauth::model::LoginUser};
+use crate::api::{
+    MonoApiServiceState,
+    error::ApiError,
+    oauth::{BotIdentity, model::LoginUser},
+};
 
 // TODO: All users are temporary allowed during development stage
 const POLICY_CONTENT: &str = r#"
@@ -134,13 +138,16 @@ pub async fn cedar_guard(
     //     .ok_or_else(|| MegaError::with_message(format!("Change list not found for link: {}", link)))?;
     // let repo_path: PathBuf = cl_model.path.into();
 
-    let user = req.extensions().get::<LoginUser>().cloned();
+    let login_user = req.extensions().get::<LoginUser>();
+    let bot_identity = req.extensions().get::<BotIdentity>();
 
-    let _username = match user {
-        Some(user) => user.username,
-        None => "reader".to_string(),
+    let (principal_type, principal_id) = if let Some(bot) = bot_identity {
+        ("Bot".to_string(), bot.bot.id.to_string())
+    } else if let Some(user) = login_user {
+        ("User".to_string(), user.username.clone())
+    } else {
+        ("User".to_string(), "reader".to_string())
     };
-    let username = "reader".to_string(); // For testing purpose only
 
     // let policy_path = repo_path.join("cedar/policies.cedar");
     // let policy_content = get_blob_string(&state, &policy_path).await?;
@@ -149,12 +156,12 @@ pub async fn cedar_guard(
     let entity_store = EntityStore::from_ref(&state);
     let c = CedarContext::from(entity_store, &policy_content)?;
 
-    authorize(&c, &username, &action.to_string())
+    authorize(&c, &principal_type, &principal_id, &action.to_string())
         .await
         .map_err(|e| {
             tracing::debug!(
                 "Authorization failed for {}: {}",
-                &username,
+                &principal_id,
                 &action.to_string()
             );
             ApiError::with_status(
@@ -177,14 +184,14 @@ pub async fn cedar_guard(
 
 async fn authorize(
     cedar_context: &CedarContext,
-    user_id: &str,
-    // repo_id: &str,
+    principal_type: &str,
+    principal_id: &str,
     action: &str,
 ) -> Result<(), MegaError> {
-    let user_entity = EntityId::from_str(user_id)?;
+    let user_entity = EntityId::from_str(principal_id)?;
     let action_entity = EntityId::from_str(action)?;
 
-    let role_entity = EntityTypeName::from_str("User")?;
+    let role_entity = EntityTypeName::from_str(principal_type)?;
     let actiontype_entity = EntityTypeName::from_str("Action")?;
 
     let principal = SaturnEUid::from(EntityUid::from_type_name_and_id(role_entity, user_entity));

--- a/mono/src/api/oauth/mod.rs
+++ b/mono/src/api/oauth/mod.rs
@@ -13,6 +13,7 @@ use axum_extra::{
     headers::{self, Authorization, authorization::Bearer},
     typed_header::TypedHeaderRejectionReason,
 };
+use callisto::{bot_tokens, bots};
 use chrono::{Duration, Utc};
 use common::config::OauthConfig;
 use http::request::Parts;
@@ -190,6 +191,59 @@ pub struct AuthRedirect;
 impl IntoResponse for AuthRedirect {
     fn into_response(self) -> Response {
         (StatusCode::UNAUTHORIZED, "Login first").into_response()
+    }
+}
+
+pub struct BotIdentity {
+    pub bot: bots::Model,
+    pub token: bot_tokens::Model,
+}
+
+impl<S> FromRequestParts<S> for BotIdentity
+where
+    MonoApiServiceState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = AuthRedirect;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        // Extract Authorization: Bearer <token> header
+        let bearer = parts
+            .extract::<TypedHeader<Authorization<Bearer>>>()
+            .await
+            .map_err(|e| {
+                tracing::debug!("BotIdentity: missing or invalid Authorization header: {e}");
+                AuthRedirect
+            })?
+            .0
+            .0;
+
+        let raw_token = bearer.token();
+        const BOT_PREFIX: &str = "bot_";
+
+        // Enforce bot_ prefix for bot identity routes
+        if !raw_token.starts_with(BOT_PREFIX) {
+            tracing::debug!("BotIdentity: bearer token does not start with expected bot_ prefix");
+            return Err(AuthRedirect);
+        }
+
+        // Delegate token validation to Jupiter storage (BotsStorage)
+        let state_ref = MonoApiServiceState::from_ref(state);
+        let bots_storage = state_ref.storage.bots_storage();
+
+        // BotsStorage::find_bot_by_token is tolerant to presence/absence of the prefix,
+        // but we pass the original token string here for clarity.
+        match bots_storage.find_bot_by_token(raw_token).await {
+            Ok(Some((bot, token))) => Ok(BotIdentity { bot, token }),
+            Ok(None) => {
+                tracing::warn!("BotIdentity: bot token not found, revoked, or expired");
+                Err(AuthRedirect)
+            }
+            Err(e) => {
+                tracing::error!("BotIdentity: error while validating bot token: {:?}", e);
+                Err(AuthRedirect)
+            }
+        }
     }
 }
 

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
     extract::{Path, State},
 };
+use ceres::model::bots::{BotRes, ChangeInstallationStatus, InstallBotReq, InstallationTargetType};
 use chrono::{DateTime, Duration, Utc};
 use sea_orm::prelude::DateTimeWithTimeZone;
 use serde::{Deserialize, Serialize};
@@ -70,11 +71,133 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
     OpenApiRouter::new().nest(
         "/bots",
         OpenApiRouter::new()
+            .routes(routes!(install_bot))
+            .routes(routes!(list_installed_bot))
+            .routes(routes!(change_installation_status))
+            .routes(routes!(uninstall_bot))
             .routes(routes!(create_bot_token))
             .routes(routes!(list_bot_tokens))
             .routes(routes!(revoke_bot_token))
             .routes(routes!(revoke_all_bot_tokens)),
     )
+}
+
+/// Install bot
+#[utoipa::path(
+    post,
+    params(
+        ("id", description = "Bots ID"),
+    ),
+    path = "/{id}/installations",
+    responses(
+        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
+    ),
+    tag = BOT_TAG
+)]
+async fn install_bot(
+    state: State<MonoApiServiceState>,
+    Path(id): Path<i64>,
+    Json(json): Json<InstallBotReq>,
+) -> Result<Json<CommonResult<BotRes>>, ApiError> {
+    let bot = state
+        .storage
+        .bots_storage()
+        .install_bot(
+            id,
+            json.target_type.into(),
+            json.target_id,
+            json.installed_by,
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(bot.into()))))
+}
+
+/// Get installed bot
+#[utoipa::path(
+    get,
+    params(
+        ("id", description = "Bots ID"),
+    ),
+    path = "/{id}/installations",
+    responses(
+        (status = 200, body = CommonResult<Vec<BotRes>>, content_type = "application/json")
+    ),
+    tag = BOT_TAG
+)]
+async fn list_installed_bot(
+    state: State<MonoApiServiceState>,
+    Path(id): Path<i64>,
+) -> Result<Json<CommonResult<Vec<BotRes>>>, ApiError> {
+    let models = state
+        .storage
+        .bots_storage()
+        .get_installed_bot_by_id(id)
+        .await?
+        .into_iter()
+        .map(|m| m.into())
+        .collect();
+
+    Ok(Json(CommonResult::success(Some(models))))
+}
+
+#[utoipa::path(
+    patch,
+    params(
+        ("id", description = "Bot ID"),
+        ("installation_id", description = "Installation ID"),
+    ),
+    path = "/{id}/installations/{installation_id}",
+    responses(
+        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
+    ),
+    tag = BOT_TAG
+)]
+async fn change_installation_status(
+    state: State<MonoApiServiceState>,
+    Path((id, installation_id)): Path<(i64, i64)>,
+    Json(json): Json<ChangeInstallationStatus>,
+) -> Result<Json<CommonResult<BotRes>>, ApiError> {
+    let model = state
+        .storage
+        .bots_storage()
+        .change_installed_bot_status(
+            id,
+            json.target_type.into(),
+            installation_id,
+            json.status.into(),
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(model.into()))))
+}
+
+#[utoipa::path(
+    delete,
+    params(
+        ("id", description = "Bot ID"),
+        ("installation_id", description = "Installation ID"),
+    ),
+    path = "/{id}/installations/{installation_id}",
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = BOT_TAG
+)]
+async fn uninstall_bot(
+    state: State<MonoApiServiceState>,
+    Path((id, installation_id)): Path<(i64, i64)>,
+    Json(target_type): Json<InstallationTargetType>,
+) -> Result<Json<CommonResult<String>>, ApiError> {
+    state
+        .storage
+        .bots_storage()
+        .uninstall_bot(id, target_type.into(), installation_id)
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(
+        "Bot uninstalled successfully".to_string(),
+    ))))
 }
 
 /// POST /api/v1/bots/{bot_id}/tokens
@@ -108,7 +231,7 @@ async fn create_bot_token(
     let expires_at: Option<DateTimeWithTimeZone> = match req.expires_in {
         None => None,
         Some(seconds) => {
-            if seconds < MIN_EXPIRES_IN_SECS || seconds > MAX_EXPIRES_IN_SECS {
+            if !(MIN_EXPIRES_IN_SECS..=MAX_EXPIRES_IN_SECS).contains(&seconds) {
                 return Err(ApiError::bad_request(anyhow!(
                     "expires_in must be between {} and {} seconds",
                     MIN_EXPIRES_IN_SECS,

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -188,7 +188,7 @@ async fn list_bot_tokens(
         ("id" = i64, Path, description = "Token ID")
     ),
     responses(
-        (status = 200, body = CommonResult<()>),
+        (status = 200, description = "Token revoked successfully"),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden - admin only"),
         (status = 404, description = "Bot or token not found"),
@@ -222,7 +222,7 @@ async fn revoke_bot_token(
         ("bot_id" = i64, Path, description = "Bot ID")
     ),
     responses(
-        (status = 200, body = CommonResult<()>),
+        (status = 200, description = "All tokens revoked successfully"),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden - admin only"),
         (status = 404, description = "Bot not found"),

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -3,139 +3,219 @@ use axum::{
     Json,
     extract::{Path, State},
 };
-use ceres::model::bots::{BotRes, ChangeInstallationStatus, InstallBotReq, InstallationTargetType};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use sea_orm::prelude::DateTimeWithTimeZone;
+use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
-    api::{MonoApiServiceState, error::ApiError},
-    server::http_server::BOTS_TAG,
+    api::{
+        MonoApiServiceState,
+        api_common::group_permission::ensure_admin,
+        error::ApiError,
+        oauth::model::LoginUser,
+    },
+    server::http_server::BOT_TAG,
 };
+
+/// Request body for creating a new bot token.
+#[derive(Deserialize, ToSchema)]
+pub struct CreateBotTokenRequest {
+    /// Human-readable token name for identification.
+    pub token_name: String,
+    /// Optional relative expiry in seconds from now.
+    pub expires_in: Option<i64>,
+}
+
+/// Response body when a bot token is created.
+///
+/// Note: `token_plain` is only returned once and is never stored in plaintext.
+#[derive(Serialize, ToSchema)]
+pub struct CreateBotTokenResponse {
+    pub id: i64,
+    pub token_name: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub token_plain: String,
+}
+
+/// Item in the list bot tokens response.
+#[derive(Serialize, ToSchema)]
+pub struct ListBotTokenItem {
+    pub id: i64,
+    pub token_name: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub revoked: bool,
+    pub created_at: DateTime<Utc>,
+}
 
 pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
     OpenApiRouter::new().nest(
         "/bots",
         OpenApiRouter::new()
-            .routes(routes!(install_bot))
-            .routes(routes!(list_installed_bot))
-            .routes(routes!(change_installation_status))
-            .routes(routes!(uninstall_bot)),
+            .routes(routes!(create_bot_token))
+            .routes(routes!(list_bot_tokens))
+            .routes(routes!(revoke_bot_token))
+            .routes(routes!(revoke_all_bot_tokens)),
     )
 }
 
-/// Install bot
+/// POST /api/v1/bots/{bot_id}/tokens
+///
+/// Create a new bot token. Only admins can perform this operation.
 #[utoipa::path(
     post,
+    path = "/{bot_id}/tokens",
+    request_body = CreateBotTokenRequest,
     params(
-        ("id", description = "Bots ID"),
+        ("bot_id" = i64, Path, description = "Bot ID")
     ),
-    path = "/{id}/installations ",
     responses(
-        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
+        (status = 200, body = CommonResult<CreateBotTokenResponse>),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - admin only"),
+        (status = 404, description = "Bot not found"),
     ),
-    tag = BOTS_TAG
+    tag = BOT_TAG
 )]
-async fn install_bot(
-    state: State<MonoApiServiceState>,
-    Path(id): Path<i64>,
-    Json(json): Json<InstallBotReq>,
-) -> Result<Json<CommonResult<BotRes>>, ApiError> {
-    let bot = state
+async fn create_bot_token(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+    Path(bot_id): Path<i64>,
+    Json(req): Json<CreateBotTokenRequest>,
+) -> Result<Json<CommonResult<CreateBotTokenResponse>>, ApiError> {
+    ensure_admin(&state, &user).await?;
+
+    let expires_at: Option<DateTimeWithTimeZone> = req.expires_in.map(|seconds| {
+        let when = Utc::now() + Duration::seconds(seconds);
+        DateTimeWithTimeZone::from(when)
+    });
+
+    let (model, token_plain) = state
         .storage
         .bots_storage()
-        .install_bot(
-            id,
-            json.target_type.into(),
-            json.target_id,
-            json.installed_by,
-        )
+        .generate_bot_token(bot_id, &req.token_name, expires_at)
         .await?;
 
-    Ok(Json(CommonResult::success(Some(bot.into()))))
+    let resp = CreateBotTokenResponse {
+        id: model.id,
+        token_name: model.token_name,
+        expires_at: model.expires_at.map(|dt| dt.with_timezone(&Utc)),
+        token_plain,
+    };
+
+    Ok(Json(CommonResult::success(Some(resp))))
 }
 
-/// Get installed bot
+/// GET /api/v1/bots/{bot_id}/tokens
+///
+/// List existing tokens for a bot (without plaintext).
 #[utoipa::path(
     get,
+    path = "/{bot_id}/tokens",
     params(
-        ("id", description = "Bots ID"),
+        ("bot_id" = i64, Path, description = "Bot ID")
     ),
-    path = "/{id}/installations",
     responses(
-        (status = 200, body = CommonResult<Vec<BotRes>>, content_type = "application/json")
+        (status = 200, body = CommonResult<Vec<ListBotTokenItem>>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - admin only"),
+        (status = 404, description = "Bot not found"),
     ),
-    tag = BOTS_TAG
+    tag = BOT_TAG
 )]
-async fn list_installed_bot(
-    state: State<MonoApiServiceState>,
-    Path(id): Path<i64>,
-) -> Result<Json<CommonResult<Vec<BotRes>>>, ApiError> {
-    let models = state
+async fn list_bot_tokens(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+    Path(bot_id): Path<i64>,
+) -> Result<Json<CommonResult<Vec<ListBotTokenItem>>>, ApiError> {
+    ensure_admin(&state, &user).await?;
+
+    let tokens = state
         .storage
         .bots_storage()
-        .get_installed_bot_by_id(id)
-        .await?
-        .into_iter()
-        .map(|m| m.into())
-        .collect();
-
-    Ok(Json(CommonResult::success(Some(models))))
-}
-
-#[utoipa::path(
-    patch,
-    params(
-        ("id", description = "Bot ID"),
-        ("installation_id", description = "Installation ID"),
-    ),
-    path = "/{id}/installations/{installation_id}",
-    responses(
-        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
-    ),
-    tag = BOTS_TAG
-)]
-async fn change_installation_status(
-    state: State<MonoApiServiceState>,
-    Path((id, installation_id)): Path<(i64, i64)>,
-    Json(json): Json<ChangeInstallationStatus>,
-) -> Result<Json<CommonResult<BotRes>>, ApiError> {
-    let model = state
-        .storage
-        .bots_storage()
-        .change_installed_bot_status(
-            id,
-            json.target_type.into(),
-            installation_id,
-            json.status.into(),
-        )
+        .list_bot_tokens(bot_id)
         .await?;
 
-    Ok(Json(CommonResult::success(Some(model.into()))))
+    let items = tokens
+        .into_iter()
+        .map(|t| ListBotTokenItem {
+            id: t.id,
+            token_name: t.token_name,
+            expires_at: t.expires_at.map(|dt| dt.with_timezone(&Utc)),
+            revoked: t.revoked,
+            created_at: t.created_at.with_timezone(&Utc),
+        })
+        .collect();
+
+    Ok(Json(CommonResult::success(Some(items))))
 }
 
+/// DELETE /api/v1/bots/{bot_id}/tokens/{id}
+///
+/// Revoke a single bot token. Idempotent.
 #[utoipa::path(
     delete,
+    path = "/{bot_id}/tokens/{id}",
     params(
-        ("id", description = "Bot ID"),
-        ("installation_id", description = "Installation ID"),
+        ("bot_id" = i64, Path, description = "Bot ID"),
+        ("id" = i64, Path, description = "Token ID")
     ),
-    path = "/{id}/installations/{installation_id}",
     responses(
-        (status = 200, body = CommonResult<String>, content_type = "application/json")
+        (status = 200, body = CommonResult<()>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - admin only"),
+        (status = 404, description = "Bot or token not found"),
     ),
-    tag = BOTS_TAG
+    tag = BOT_TAG
 )]
-async fn uninstall_bot(
-    state: State<MonoApiServiceState>,
-    Path((id, installation_id)): Path<(i64, i64)>,
-    Json(target_type): Json<InstallationTargetType>,
-) -> Result<Json<CommonResult<String>>, ApiError> {
+async fn revoke_bot_token(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+    Path((bot_id, token_id)): Path<(i64, i64)>,
+) -> Result<Json<CommonResult<()>>, ApiError> {
+    ensure_admin(&state, &user).await?;
+
     state
         .storage
         .bots_storage()
-        .uninstall_bot(id, target_type.into(), installation_id)
+        .revoke_bot_token(bot_id, token_id)
         .await?;
 
-    Ok(Json(CommonResult::success(Some(
-        "Bot uninstalled successfully".to_string(),
-    ))))
+    Ok(Json(CommonResult::success(None)))
 }
+
+/// POST /api/v1/bots/{bot_id}/tokens/revoke_all
+///
+/// Revoke all tokens for a given bot. Idempotent.
+#[utoipa::path(
+    post,
+    path = "/{bot_id}/tokens/revoke_all",
+    params(
+        ("bot_id" = i64, Path, description = "Bot ID")
+    ),
+    responses(
+        (status = 200, body = CommonResult<()>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - admin only"),
+        (status = 404, description = "Bot not found"),
+    ),
+    tag = BOT_TAG
+)]
+async fn revoke_all_bot_tokens(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+    Path(bot_id): Path<i64>,
+) -> Result<Json<CommonResult<()>>, ApiError> {
+    ensure_admin(&state, &user).await?;
+
+    state
+        .storage
+        .bots_storage()
+        .revoke_bot_tokens_by_bot(bot_id)
+        .await?;
+
+    Ok(Json(CommonResult::success(None)))
+}
+

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -4,16 +4,14 @@ use axum::{
     extract::{Path, State},
 };
 use chrono::{DateTime, Duration, Utc};
-use serde::{Deserialize, Serialize};
 use sea_orm::prelude::DateTimeWithTimeZone;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
     api::{
-        MonoApiServiceState,
-        api_common::group_permission::ensure_admin,
-        error::ApiError,
+        MonoApiServiceState, api_common::group_permission::ensure_admin, error::ApiError,
         oauth::model::LoginUser,
     },
     server::http_server::BOT_TAG,
@@ -132,11 +130,7 @@ async fn list_bot_tokens(
 ) -> Result<Json<CommonResult<Vec<ListBotTokenItem>>>, ApiError> {
     ensure_admin(&state, &user).await?;
 
-    let tokens = state
-        .storage
-        .bots_storage()
-        .list_bot_tokens(bot_id)
-        .await?;
+    let tokens = state.storage.bots_storage().list_bot_tokens(bot_id).await?;
 
     let items = tokens
         .into_iter()
@@ -218,4 +212,3 @@ async fn revoke_all_bot_tokens(
 
     Ok(Json(CommonResult::success(None)))
 }
-

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use api_model::common::CommonResult;
 use axum::{
     Json,
@@ -16,6 +17,24 @@ use crate::{
     },
     server::http_server::BOT_TAG,
 };
+
+/// Maximum allowed expires_in in seconds (10 years).
+const MAX_EXPIRES_IN_SECS: i64 = 365 * 24 * 3600 * 10;
+/// Minimum allowed expires_in in seconds.
+const MIN_EXPIRES_IN_SECS: i64 = 1;
+
+async fn ensure_bot_exists(state: &MonoApiServiceState, bot_id: i64) -> Result<(), ApiError> {
+    let bot = state
+        .storage
+        .bots_storage()
+        .get_bot_by_id(bot_id)
+        .await
+        .map_err(ApiError::from)?;
+    if bot.is_none() {
+        return Err(ApiError::not_found(anyhow!("Bot not found")));
+    }
+    Ok(())
+}
 
 /// Request body for creating a new bot token.
 #[derive(Deserialize, ToSchema)]
@@ -84,11 +103,22 @@ async fn create_bot_token(
     Json(req): Json<CreateBotTokenRequest>,
 ) -> Result<Json<CommonResult<CreateBotTokenResponse>>, ApiError> {
     ensure_admin(&state, &user).await?;
+    ensure_bot_exists(&state, bot_id).await?;
 
-    let expires_at: Option<DateTimeWithTimeZone> = req.expires_in.map(|seconds| {
-        let when = Utc::now() + Duration::seconds(seconds);
-        DateTimeWithTimeZone::from(when)
-    });
+    let expires_at: Option<DateTimeWithTimeZone> = match req.expires_in {
+        None => None,
+        Some(seconds) => {
+            if seconds < MIN_EXPIRES_IN_SECS || seconds > MAX_EXPIRES_IN_SECS {
+                return Err(ApiError::bad_request(anyhow!(
+                    "expires_in must be between {} and {} seconds",
+                    MIN_EXPIRES_IN_SECS,
+                    MAX_EXPIRES_IN_SECS
+                )));
+            }
+            let when = Utc::now() + Duration::seconds(seconds);
+            Some(DateTimeWithTimeZone::from(when))
+        }
+    };
 
     let (model, token_plain) = state
         .storage
@@ -129,6 +159,7 @@ async fn list_bot_tokens(
     Path(bot_id): Path<i64>,
 ) -> Result<Json<CommonResult<Vec<ListBotTokenItem>>>, ApiError> {
     ensure_admin(&state, &user).await?;
+    ensure_bot_exists(&state, bot_id).await?;
 
     let tokens = state.storage.bots_storage().list_bot_tokens(bot_id).await?;
 
@@ -170,6 +201,7 @@ async fn revoke_bot_token(
     Path((bot_id, token_id)): Path<(i64, i64)>,
 ) -> Result<Json<CommonResult<()>>, ApiError> {
     ensure_admin(&state, &user).await?;
+    ensure_bot_exists(&state, bot_id).await?;
 
     state
         .storage
@@ -203,6 +235,7 @@ async fn revoke_all_bot_tokens(
     Path(bot_id): Path<i64>,
 ) -> Result<Json<CommonResult<()>>, ApiError> {
     ensure_admin(&state, &user).await?;
+    ensure_bot_exists(&state, bot_id).await?;
 
     state
         .storage

--- a/mono/src/api/router/mod.rs
+++ b/mono/src/api/router/mod.rs
@@ -2,7 +2,6 @@ pub mod admin_router;
 pub mod bot_router;
 pub mod buck_router;
 pub mod build_trigger_router;
-pub mod bot_router;
 pub mod cl_router;
 pub mod code_review_router;
 pub mod commit_router;

--- a/mono/src/api/router/mod.rs
+++ b/mono/src/api/router/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_router;
 pub mod bot_router;
 pub mod buck_router;
 pub mod build_trigger_router;
+pub mod bot_router;
 pub mod cl_router;
 pub mod code_review_router;
 pub mod commit_router;

--- a/mono/src/server/http_server.rs
+++ b/mono/src/server/http_server.rs
@@ -429,7 +429,7 @@ pub const CODE_REVIEW_TAG: &str = "Code Review";
 pub const BUILD_TRIGGER_TAG: &str = "Build Trigger";
 pub const GROUP_PERMISSION_TAG: &str = "Group Permission Management";
 pub const WEBHOOK_TAG: &str = "Webhook";
-pub const BOTS_TAG: &str = "Bots";
+pub const BOT_TAG: &str = "Bot Management";
 #[derive(OpenApi)]
 #[openapi()]
 struct ApiDoc;


### PR DESCRIPTION
#### Related issue
#1999 

#### Summary

- Add secure, HMAC-based bot token storage in Jupiter, exposing only non-plaintext DTOs.
- Introduce `AuditStorage` as a centralized audit logging entrypoint for bot-related flows.
- Add Mono-layer HTTP APIs for bot token lifecycle management under `/api/v1/bots/{bot_id}/tokens`.

#### Details

- **Bot token storage (Jupiter)**
  - Add `BotTokenInfo` DTO for listing bot tokens without exposing plaintext.
  - Extend `BotsStorage` with:
    - `generate_bot_token` that creates high-entropy random bot tokens, Base64-encodes them, prefixes with `bot_`, stores only an HMAC-SHA256 hash of the token body (without prefix) in `bot_tokens.token_hash`, and returns the plaintext token once.
    - `list_bot_tokens` to return per-bot token metadata ordered by `created_at`, without plaintext values.
    - `revoke_bot_token` and `revoke_bot_tokens_by_bot` to mark tokens as revoked in an idempotent way.
    - `find_bot_by_token` that:
      - Accepts tokens with or without the `bot_` prefix.
      - Computes the HMAC-SHA256 hash of the token body and looks it up in `bot_tokens`.
      - Enforces `revoked = false` and `expires_at` either `NULL` or in the future.
      - Returns `None` when the token or corresponding bot record is missing.
  - Load the HMAC key from `MEGA_BOT_TOKEN_HMAC_SECRET`, returning a clear `MegaError` if it is missing or invalid.

- **Audit logging (Jupiter)**
  - Introduce new module `audit_storage.rs` defining `AuditStorage { base: BaseStorage }`.
  - Implement `log_audit(actor_id, actor_type: ActorTypeEnum, action: AuditActionEnum, target_type: TargetTypeEnum, target_id, metadata: Option<serde_json::Value>)` which:
    - Generates a new `id` via `IdInstance::next_id()`.
    - Fills all enum fields using `callisto`-generated types to stay aligned with the DB schema.
    - Converts optional JSON metadata into `Json`.
    - Sets `created_at = Utc::now()` and inserts a row into `audit_logs`.
  - Update `storage::mod`:
    - Register `pub mod audit_storage;`.
    - Add `audit_storage: AuditStorage` to `Storage` / `AppService`, initialize it in `Storage::new()` and `AppService::mock()`.
    - Expose `pub fn audit_storage(&self) -> AuditStorage` for higher layers.
  - Intended usage:
    - Record bot token lifecycle events (generate / revoke / revoke_all).
    - Record bot-initiated business API calls with appropriate `actor_type = Bot`, `target_type`, `target_id`, and richer `metadata` (bot ID, permission scope, installation targets, API path, decision results, etc.).

- **Mono HTTP API for bot token management**
  - Add `bot_router` that exposes admin-only bot token endpoints, all requiring authenticated `LoginUser` and an `ensure_admin` check:
    - `POST /api/v1/bots/{bot_id}/tokens`  
      - Creates a new bot token using Jupiter `BotsStorage::generate_bot_token`.
      - Returns the plaintext token once (`token_plain`), plus metadata.
    - `GET /api/v1/bots/{bot_id}/tokens`  
      - Lists existing tokens for a bot without exposing plaintext values.
    - `DELETE /api/v1/bots/{bot_id}/tokens/{id}`  
      - Revokes a single token; the operation is idempotent.
    - `POST /api/v1/bots/{bot_id}/tokens/revoke_all`  
      - Revokes all tokens for the given bot; also idempotent.
  - Define request/response DTOs for token creation and listing; tag endpoints and schemas with `BOT_TAG = "Bot Management"` for OpenAPI.
  - Register `bot_router` in the main `api_router` so the endpoints are served under `/api/v1`.
  - Expose `bots_storage()` from Jupiter `Storage` so Mono can call:
    - `generate_bot_token`
    - `list_bot_tokens`
    - `revoke_bot_token`
    - `revoke_bot_tokens_by_bot`