### PR TITLE
chore(orion): tune buck2 and scorpio config

### DIFF
--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -32,5 +32,5 @@ utoipa.workspace = true
 common = { path = "../common" }
 ring = "0.17.14"
 hex = { workspace = true }
-scorpiofs = "0.1.1"
+scorpiofs = "0.2.0"
 tokio-util = { workspace = true }

--- a/orion/buck/run.rs
+++ b/orion/buck/run.rs
@@ -59,6 +59,9 @@ impl Buck2 {
 
     pub fn command(&self) -> Command {
         let mut command = Command::new(&self.program);
+        command
+            .env("BUCKD_STARTUP_TIMEOUT", "30")
+            .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200");
         match &self.isolation_dir {
             None => {}
             Some(isolation_dir) => {

--- a/orion/runner-config/scorpio.toml
+++ b/orion/runner-config/scorpio.toml
@@ -22,8 +22,8 @@ git_email = "admin@mega.org"
 
 # Dicfuse 读取配置
 dicfuse_readable = "true"
-load_dir_depth = "3"
-fetch_file_thread = "10"
+load_dir_depth = "5"
+fetch_file_thread = "20"
 dicfuse_import_concurrency = "4"
 dicfuse_dir_sync_ttl_secs = "5"
 dicfuse_reply_ttl_secs = "2"

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -296,6 +296,8 @@ fn get_repo_targets(file_name: &str, repo_path: &Path) -> anyhow::Result<Targets
         tracing::debug!("Get targets for repo {repo_path:?} (attempt {attempt}/{MAX_ATTEMPTS})");
         let mut command = std::process::Command::new("buck2");
         command
+            .env("BUCKD_STARTUP_TIMEOUT", "30")
+            .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200")
             .args(targets_arguments())
             .args(["--isolation-dir", &isolation_dir]);
         command.current_dir(repo_path);
@@ -748,7 +750,9 @@ pub async fn build(
         let mut cmd = Command::new("buck2");
         // --event-log and --build-report are used to collect build execution status
         // at target level (e.g. pending / running / succeeded / failed).
-        cmd.args([
+        cmd.env("BUCKD_STARTUP_TIMEOUT", "30")
+            .env("BUCKD_STARTUP_INIT_TIMEOUT", "120")
+            .args([
             "--isolation-dir", &isolation_dir,
             "--event-log", EVENT_LOG_FILE,
         ]);


### PR DESCRIPTION
- Add BUCKD_STARTUP_TIMEOUT=30 and BUCKD_STARTUP_INIT_TIMEOUT to all buck2 command invocations (Buck2::command, get_repo_targets, build) to prevent daemon startup timeouts under slow I/O environments
- Bump scorpiofs dependency from 0.1.1 to 0.2.0
- Increase scorpio load_dir_depth from 3 to 5 and fetch_file_thread from 10 to 20 for better prefetch coverage and concurrency