### PR TITLE
feat(orion): add Dicfuse warmup, remove isolation-dir, fix event log tailing.

### DIFF
--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -181,6 +181,11 @@ jobs:
             sudo chmod +x /home/orion/orion-runner/run.sh
             sudo chmod +x /home/orion/orion-runner/cleanup.sh
 
+            # Grant CAP_DAC_READ_SEARCH file capability so orion can bypass
+            # DAC read/search checks without running as root
+            sudo setcap cap_dac_read_search+ep /home/orion/orion-runner/orion
+            getcap /home/orion/orion-runner/orion
+
             # Update systemd service file if changed
             if [ -f /home/orion/orion-runner/orion-runner.service ]; then
                 cp /home/orion/orion-runner/orion-runner.service /etc/systemd/system/
@@ -284,6 +289,11 @@ jobs:
             sudo chmod +x /home/orion/orion-runner/orion
             sudo chmod +x /home/orion/orion-runner/run.sh
             sudo chmod +x /home/orion/orion-runner/cleanup.sh
+
+            # Grant CAP_DAC_READ_SEARCH file capability so orion can bypass
+            # DAC read/search checks without running as root
+            sudo setcap cap_dac_read_search+ep /home/orion/orion-runner/orion
+            getcap /home/orion/orion-runner/orion
 
             # Update systemd service file if changed
             if [ -f /home/orion/orion-runner/orion-runner.service ]; then

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 api-model = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs", "process"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
@@ -30,7 +30,5 @@ td_util_buck = { path = "./buck" }
 thiserror = { workspace = true }
 utoipa.workspace = true
 common = { path = "../common" }
-ring = "0.17.14"
-hex = { workspace = true }
-scorpiofs = "0.2.0"
+scorpiofs = "0.2.1"
 tokio-util = { workspace = true }

--- a/orion/buck/run.rs
+++ b/orion/buck/run.rs
@@ -32,8 +32,6 @@ pub struct Buck2 {
     program: String,
     /// The result of running `root`, if we have done so yet.
     root: Option<PathBuf>,
-    /// The isolation directory to always use when invoking buck
-    isolation_dir: Option<String>,
 }
 
 impl Buck2 {
@@ -41,7 +39,6 @@ impl Buck2 {
         Self {
             program,
             root: Some(root),
-            isolation_dir: None,
         }
     }
 
@@ -49,12 +46,7 @@ impl Buck2 {
         Self {
             program,
             root: Some(root),
-            isolation_dir: None,
         }
-    }
-
-    pub fn set_isolation_dir(&mut self, isolation_dir: String) {
-        self.isolation_dir = Some(isolation_dir);
     }
 
     pub fn command(&self) -> Command {
@@ -62,12 +54,6 @@ impl Buck2 {
         command
             .env("BUCKD_STARTUP_TIMEOUT", "30")
             .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200");
-        match &self.isolation_dir {
-            None => {}
-            Some(isolation_dir) => {
-                command.args(["--isolation-dir", isolation_dir]);
-            }
-        }
         command
     }
 

--- a/orion/scorpio.toml
+++ b/orion/scorpio.toml
@@ -8,22 +8,22 @@
 # ==============================================================================
 
 # Mega 服务地址（本地 mono 服务）
-base_url = "https://git.buck2hub.com"
-lfs_url = "https://git.buck2hub.com"
+base_url = "https://git.gitmega.com"
+lfs_url = "https://git.gitmega.com"
 
 # Dicfuse 数据存储
 store_path = "/tmp/megadir/store"
 
 # Scorpio daemon 主挂载点（orion 不再启动 scorpio daemon，但 scorpiofs 仍需此配置）
 workspace = "/tmp/megadir/mount"
-
+config_file = "./config.toml"
 # Git 提交信息
 git_author = "MEGA"
 git_email = "admin@mega.org"
 
 # Dicfuse 读取配置
 dicfuse_readable = "true"
-load_dir_depth = "3"
+load_dir_depth = "5"
 fetch_file_thread = "10"
 dicfuse_import_concurrency = "4"
 dicfuse_dir_sync_ttl_secs = "5"

--- a/orion/src/antares.rs
+++ b/orion/src/antares.rs
@@ -3,7 +3,7 @@
 //! This module provides a singleton wrapper around `scorpiofs::AntaresManager`
 //! for managing overlay filesystem mounts used during build operations.
 
-use std::{error::Error, io, path::PathBuf, sync::Arc};
+use std::{error::Error, io, path::PathBuf, sync::Arc, time::Duration};
 
 use scorpiofs::{AntaresConfig, AntaresManager, AntaresPaths};
 use tokio::sync::OnceCell;
@@ -120,6 +120,43 @@ pub async fn mount_job(job_id: &str, cl: Option<&str>) -> Result<AntaresConfig, 
         .map_err(Into::into)
 }
 
+/// Initialize Antares during Orion startup and eagerly trigger Dicfuse import.
+///
+/// This keeps the first build request from paying the full Dicfuse cold-start
+/// cost. Readiness waiting runs in the background so Orion can continue booting.
+#[allow(dead_code)] // Called from the bin target (main.rs), not visible to lib check.
+pub(crate) async fn warmup_dicfuse() -> Result<(), DynError> {
+    tracing::info!("Initializing Antares Dicfuse during Orion startup");
+    let manager = get_manager().await?;
+    let dicfuse = manager.dicfuse();
+
+    // Idempotent: safe even if the manager already started import internally.
+    dicfuse.start_import();
+
+    tokio::spawn(async move {
+        const DICFUSE_WARMUP_TIMEOUT_SECS: u64 = 1200;
+        tracing::info!(
+            "Waiting for Antares Dicfuse warmup to finish (timeout: {}s)",
+            DICFUSE_WARMUP_TIMEOUT_SECS
+        );
+
+        match tokio::time::timeout(
+            Duration::from_secs(DICFUSE_WARMUP_TIMEOUT_SECS),
+            dicfuse.store.wait_for_ready(),
+        )
+        .await
+        {
+            Ok(_) => tracing::info!("Antares Dicfuse warmup completed"),
+            Err(_) => tracing::warn!(
+                "Antares Dicfuse warmup timed out after {}s",
+                DICFUSE_WARMUP_TIMEOUT_SECS
+            ),
+        }
+    });
+
+    Ok(())
+}
+
 /// Unmount and cleanup a job overlay filesystem.
 ///
 /// # Arguments
@@ -127,6 +164,7 @@ pub async fn mount_job(job_id: &str, cl: Option<&str>) -> Result<AntaresConfig, 
 ///
 /// # Returns
 /// The `AntaresConfig` of the unmounted job if it existed.
+#[allow(dead_code)]
 pub async fn unmount_job(job_id: &str) -> Result<Option<AntaresConfig>, DynError> {
     tracing::debug!("Unmounting Antares job: job_id={}", job_id);
     get_manager()

--- a/orion/src/antares.rs
+++ b/orion/src/antares.rs
@@ -134,14 +134,17 @@ pub(crate) async fn warmup_dicfuse() -> Result<(), DynError> {
     dicfuse.start_import();
 
     tokio::spawn(async move {
-        const DICFUSE_WARMUP_TIMEOUT_SECS: u64 = 1200;
+        let warmup_timeout_secs: u64 = std::env::var("ORION_DICFUSE_WARMUP_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1200);
         tracing::info!(
             "Waiting for Antares Dicfuse warmup to finish (timeout: {}s)",
-            DICFUSE_WARMUP_TIMEOUT_SECS
+            warmup_timeout_secs
         );
 
         match tokio::time::timeout(
-            Duration::from_secs(DICFUSE_WARMUP_TIMEOUT_SECS),
+            Duration::from_secs(warmup_timeout_secs),
             dicfuse.store.wait_for_ready(),
         )
         .await
@@ -149,7 +152,7 @@ pub(crate) async fn warmup_dicfuse() -> Result<(), DynError> {
             Ok(_) => tracing::info!("Antares Dicfuse warmup completed"),
             Err(_) => tracing::warn!(
                 "Antares Dicfuse warmup timed out after {}s",
-                DICFUSE_WARMUP_TIMEOUT_SECS
+                warmup_timeout_secs
             ),
         }
     });

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -118,7 +118,7 @@ fn preheat(repo_path: &Path) -> anyhow::Result<()> {
         repo = ?repo_path,
         elapsed_ms = start.elapsed().as_millis(),
         depth = depth,
-        ": completed"
+        "preheat: completed"
     );
     Ok(())
 }

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -90,6 +90,7 @@ pub async fn mount_antares_fs(
 /// # Returns
 /// * `Ok(true)` - Unmount succeeded
 /// * `Err` - Unmount failed
+#[allow(dead_code)]
 pub async fn unmount_antares_fs(mount_id: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
     tracing::info!("Starting unmount for mount_id: {}", mount_id);
 
@@ -107,6 +108,7 @@ pub async fn unmount_antares_fs(mount_id: &str) -> Result<bool, Box<dyn Error + 
 ///
 /// We use a shallow Rust-native walk (instead of `ls -lR`) for better control
 /// and error resilience.
+#[allow(dead_code)]
 fn preheat(repo_path: &Path) -> anyhow::Result<()> {
     tracing::info!(repo = ?repo_path, "preheat: starting lightweight metadata warmup");
     let start = std::time::Instant::now();
@@ -116,7 +118,7 @@ fn preheat(repo_path: &Path) -> anyhow::Result<()> {
         repo = ?repo_path,
         elapsed_ms = start.elapsed().as_millis(),
         depth = depth,
-        "preheat: completed"
+        ": completed"
     );
     Ok(())
 }
@@ -238,59 +240,10 @@ fn resolve_config_path() -> Option<PathBuf> {
     None
 }
 
-/// Derive a stable per-mount buck2 isolation directory name.
-///
-/// # Why `--isolation-dir` is required
-///
-/// Although we always mount the **same monorepo** (`path = "/"`), every call
-/// to `mount_antares_fs()` goes through `POST /antares/mounts` which creates
-/// a **new UUID** and therefore a **new mountpoint path** each time:
-///
-/// ```text
-///   build task A  →  mount_antares_fs(job="A-1", path="/", cl=None)
-///                     → mountpoint = /var/lib/antares/mounts/<uuid-1>
-///
-///   build task A  →  mount_antares_fs(job="A-1", path="/", cl="CL-42")
-///                     → mountpoint = /var/lib/antares/mounts/<uuid-2>
-///
-///   build task B  →  mount_antares_fs(job="B-1", path="/", cl=None)
-///                     → mountpoint = /var/lib/antares/mounts/<uuid-3>
-/// ```
-///
-/// Without `--isolation-dir`, Buck2 uses a **single default daemon** per
-/// `<project_root>`.  Because the project root changes with every mount UUID,
-/// this usually just causes redundant daemon restarts.  But if two concurrent
-/// builds happen to share the same `project_root` (e.g., via retry in
-/// `MAX_TARGETS_ATTEMPTS`), the second buck2 invocation would talk to the
-/// first daemon whose internal paths point at a **stale** mountpoint — leading
-/// to `ESTALE` / `ENOENT` cascades.
-///
-/// By deriving `--isolation-dir` from `SHA256(repo_path)`, we get:
-/// - **Same mount path → same daemon** (avoids daemon startup cost on retry)
-/// - **Different mount paths → different daemons** (avoids cross-contamination)
-///
-/// # Format
-///
-/// Buck2 `--isolation-dir` expects a plain directory **name** (no path
-/// separators).  Buck2 itself stores daemon state under
-/// `<project_root>/.buck2/<isolation_dir>/`, so we only need to return a
-/// unique name – not a full path.
-fn buck2_isolation_dir(repo_path: &Path) -> anyhow::Result<String> {
-    let digest = ring::digest::digest(
-        &ring::digest::SHA256,
-        repo_path.to_string_lossy().as_bytes(),
-    );
-    let suffix = &hex::encode(digest.as_ref())[..16];
-    Ok(format!("buck2-isolation-{suffix}"))
-}
-
 /// Get target of a specific repo under tmp directory.
 fn get_repo_targets(file_name: &str, repo_path: &Path) -> anyhow::Result<Targets> {
     const MAX_ATTEMPTS: usize = 2;
     let jsonl_path = PathBuf::from(repo_path).join(file_name);
-    let isolation_dir = buck2_isolation_dir(repo_path)?;
-
-    preheat(repo_path)?;
 
     for attempt in 1..=MAX_ATTEMPTS {
         tracing::debug!("Get targets for repo {repo_path:?} (attempt {attempt}/{MAX_ATTEMPTS})");
@@ -298,8 +251,7 @@ fn get_repo_targets(file_name: &str, repo_path: &Path) -> anyhow::Result<Targets
         command
             .env("BUCKD_STARTUP_TIMEOUT", "30")
             .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200")
-            .args(targets_arguments())
-            .args(["--isolation-dir", &isolation_dir]);
+            .args(targets_arguments());
         command.current_dir(repo_path);
         let (mut child, stdout) = spawn(command)?;
         let mut writer = file_writer(&jsonl_path)?;
@@ -345,7 +297,6 @@ async fn get_build_targets(
 
     preheat_shallow(&mount_path, preheat_shallow_depth())?;
     let mut buck2 = Buck2::with_root("buck2".to_string(), mount_path.clone());
-    buck2.set_isolation_dir(buck2_isolation_dir(&mount_path)?);
     let mut cells = CellInfo::parse(
         &buck2
             .cells()
@@ -563,6 +514,7 @@ impl MountGuard {
         }
     }
 
+    #[allow(dead_code)]
     async fn unmount(&self) {
         if self.unmounted.swap(true, Ordering::AcqRel) {
             return;
@@ -660,9 +612,8 @@ pub async fn build(
         // Both mount the same monorepo root (`path = "/"`), but each call to
         // `mount_antares_fs()` creates a **new UUID** on the Antares side, so
         // the mountpoints are different (e.g. `/var/lib/antares/mounts/<uuid>`).
-        // This is why `--isolation-dir` (derived from the mountpoint path) is
-        // necessary — it prevents Buck2 daemons from cross-contaminating
-        // between the two mounts.  See `buck2_isolation_dir()` for details.
+        // Buck2 isolates daemons by project root, so distinct mount paths
+        // naturally get separate daemons without needing `--isolation-dir`.
         let id_for_old_repo = format!("{id}-old-{attempt}");
         let (old_repo_mount_point, mount_id_old_repo) =
             mount_antares_fs(&id_for_old_repo, None).await?;
@@ -699,19 +650,22 @@ pub async fn build(
                 break;
             }
             Err(e) => {
-                guard.unmount().await;
-                guard_old_repo.unmount().await;
+                // Keep mounts alive on failure for debugging.
+                // guard.unmount().await;
+                // guard_old_repo.unmount().await;
+                tracing::warn!(
+                    "[Task {}] Failed to get build targets (attempt {}/{}): {}. Mounts kept alive for debugging (old={}, new={}).",
+                    id,
+                    attempt,
+                    MAX_TARGETS_ATTEMPTS,
+                    e,
+                    old_repo_mount_point,
+                    repo_mount_point,
+                );
                 last_targets_error = Some(e);
                 if attempt == MAX_TARGETS_ATTEMPTS {
                     break;
                 }
-                tracing::warn!(
-                    "[Task {}] Failed to get build targets (attempt {}/{}): {}. Retrying with fresh mounts...",
-                    id,
-                    attempt,
-                    MAX_TARGETS_ATTEMPTS,
-                    last_targets_error.as_ref().unwrap()
-                );
             }
         }
     }
@@ -746,18 +700,14 @@ pub async fn build(
         // Run buck2 build from the sub-project directory, not the monorepo root.
         // This ensures buck2 uses the sub-project's .buckconfig and PACKAGE files.
         let project_root = PathBuf::from(&mount_point).join(repo_prefix);
-        let isolation_dir = buck2_isolation_dir(&project_root)?;
         let mut cmd = Command::new("buck2");
         // --event-log and --build-report are used to collect build execution status
         // at target level (e.g. pending / running / succeeded / failed).
         cmd.env("BUCKD_STARTUP_TIMEOUT", "30")
-            .env("BUCKD_STARTUP_INIT_TIMEOUT", "120")
-            .args([
-            "--isolation-dir", &isolation_dir,
-            "--event-log", EVENT_LOG_FILE,
-        ]);
+            .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200");
         let cmd = cmd
             .arg("build")
+            .args(["--event-log", EVENT_LOG_FILE])
             .args(&targets)
             .arg("--target-platforms")
             .arg("prelude//platforms:default")
@@ -829,13 +779,15 @@ pub async fn build(
             }
         }
 
-        if let Some(status) = exit_status {
-            return Ok(status);
-        }
+        let status = match exit_status {
+            Some(s) => s,
+            None => child.wait().await?,
+        };
 
-        let status = child.wait().await?;
-
+        // Stop the build-status tracker cleanly.
         target_build_track.cancellation.cancel();
+        target_build_track.tail_handle.abort();
+        target_build_track.process_handle.abort();
         let _ = target_build_track.tail_handle.await;
         let _ = target_build_track.process_handle.await;
         tracing::info!("Target build status track finished");

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -46,6 +46,14 @@ static PROJECT_ROOT: Lazy<String> =
 const DEFAULT_PREHEAT_SHALLOW_DEPTH: usize = 3;
 static BUILD_CONFIG: Lazy<Option<BuildConfig>> = Lazy::new(load_build_config);
 
+/// Check whether failed-build mounts should be kept alive for debugging.
+/// Controlled by the `ORION_KEEP_FAILED_MOUNTS` environment variable (set to "1" to enable).
+fn keep_failed_mounts() -> bool {
+    std::env::var("ORION_KEEP_FAILED_MOUNTS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
 /// Mount an Antares overlay filesystem for a build job.
 ///
 /// Creates a new Antares overlay mount using scorpiofs. The underlying Dicfuse
@@ -241,6 +249,12 @@ fn resolve_config_path() -> Option<PathBuf> {
 }
 
 /// Get target of a specific repo under tmp directory.
+///
+/// Note: `preheat()` was previously called here to warm the kernel VFS/FUSE
+/// cache, but it has been removed. The new `warmup_dicfuse()` at startup
+/// populates the Dicfuse backing store which makes subsequent FUSE reads
+/// fast, and `preheat_shallow()` in `get_build_targets()` handles the
+/// per-mount VFS cache warming.
 fn get_repo_targets(file_name: &str, repo_path: &Path) -> anyhow::Result<Targets> {
     const MAX_ATTEMPTS: usize = 2;
     let jsonl_path = PathBuf::from(repo_path).join(file_name);
@@ -514,7 +528,6 @@ impl MountGuard {
         }
     }
 
-    #[allow(dead_code)]
     async fn unmount(&self) {
         if self.unmounted.swap(true, Ordering::AcqRel) {
             return;
@@ -537,21 +550,22 @@ impl Drop for MountGuard {
         if self.unmounted.load(Ordering::Acquire) {
             return;
         }
-        // TODO: Temporarily keep mounts alive — skip auto-unmount on drop.
-        // Re-enable the spawn block below once post-build inspection is no longer needed.
-        tracing::info!(
-            "[Task {}] MountGuard dropped but unmount is temporarily disabled (mount_id={}).",
-            self.task_id,
-            self.mount_id,
-        );
-        // let mount_id = self.mount_id.clone();
-        // let task_id: String = self.task_id.clone();
-        // tokio::spawn(async move {
-        //     match unmount_antares_fs(&mount_id).await {
-        //         Ok(_) => tracing::info!("[Task {}] Filesystem unmounted successfully.", task_id),
-        //         Err(e) => tracing::error!("[Task {}] Failed to unmount filesystem: {}", task_id, e),
-        //     }
-        // });
+        if keep_failed_mounts() {
+            tracing::info!(
+                "[Task {}] MountGuard dropped — unmount skipped (ORION_KEEP_FAILED_MOUNTS=1, mount_id={}).",
+                self.task_id,
+                self.mount_id,
+            );
+            return;
+        }
+        let mount_id = self.mount_id.clone();
+        let task_id: String = self.task_id.clone();
+        tokio::spawn(async move {
+            match unmount_antares_fs(&mount_id).await {
+                Ok(_) => tracing::info!("[Task {}] Filesystem unmounted successfully.", task_id),
+                Err(e) => tracing::error!("[Task {}] Failed to unmount filesystem: {}", task_id, e),
+            }
+        });
     }
 }
 
@@ -650,9 +664,15 @@ pub async fn build(
                 break;
             }
             Err(e) => {
-                // Keep mounts alive on failure for debugging.
-                // guard.unmount().await;
-                // guard_old_repo.unmount().await;
+                if keep_failed_mounts() {
+                    tracing::info!(
+                        "[Task {}] Keeping failed mounts alive for debugging (ORION_KEEP_FAILED_MOUNTS=1)",
+                        id,
+                    );
+                } else {
+                    guard.unmount().await;
+                    guard_old_repo.unmount().await;
+                }
                 tracing::warn!(
                     "[Task {}] Failed to get build targets (attempt {}/{}): {}. Mounts kept alive for debugging (old={}, new={}).",
                     id,
@@ -703,6 +723,8 @@ pub async fn build(
         let mut cmd = Command::new("buck2");
         // --event-log and --build-report are used to collect build execution status
         // at target level (e.g. pending / running / succeeded / failed).
+        // FUSE-backed repos may trigger lazy loading during daemon init, which
+        // can be slow on cold caches — allow up to 1200s for the daemon to start.
         cmd.env("BUCKD_STARTUP_TIMEOUT", "30")
             .env("BUCKD_STARTUP_INIT_TIMEOUT", "1200");
         let cmd = cmd
@@ -785,35 +807,49 @@ pub async fn build(
         };
 
         // Stop the build-status tracker cleanly.
+        // Signal the processing loop to exit via cancellation token; it will
+        // flush its remaining buffer in the cleanup path after breaking out of
+        // the select! loop.
         target_build_track.cancellation.cancel();
+        // Abort the tail task — no more events need to be ingested.
         target_build_track.tail_handle.abort();
-        target_build_track.process_handle.abort();
         let _ = target_build_track.tail_handle.await;
-        let _ = target_build_track.process_handle.await;
+        // Give the processing loop a short grace period to flush its final
+        // buffered updates after observing the cancellation signal.
+        if tokio::time::timeout(
+            Duration::from_secs(2),
+            target_build_track.process_handle,
+        )
+        .await
+        .is_err()
+        {
+            tracing::warn!("Build status processing loop did not finish within 2s grace period");
+        }
         tracing::info!("Target build status track finished");
         Ok(status)
     }
     .await;
 
-    // TODO: Temporarily keep mounts alive for debugging / post-build inspection.
-    // Unmount is intentionally skipped here. Remember to re-enable once no longer needed.
-    // mount_guard.unmount().await;
-    // mount_guard_old_repo.unmount().await;
-    tracing::info!(
-        "[Task {}] Skipping unmount — mount directories are retained for inspection: \
-         new_repo mountpoint={}, mount_id={}; \
-         old_repo mountpoint={}, mount_id={}",
-        id,
-        mount_point,
-        mount_guard.mount_id,
-        old_repo_mount_point_saved.as_deref().unwrap_or("<unknown>"),
-        mount_guard_old_repo.mount_id,
-    );
-    // Prevent the Drop impl from unmounting.
-    mount_guard.unmounted.store(true, Ordering::Release);
-    mount_guard_old_repo
-        .unmounted
-        .store(true, Ordering::Release);
+    if keep_failed_mounts() {
+        tracing::info!(
+            "[Task {}] Skipping unmount (ORION_KEEP_FAILED_MOUNTS=1) — mount directories retained: \
+             new_repo mountpoint={}, mount_id={}; \
+             old_repo mountpoint={}, mount_id={}",
+            id,
+            mount_point,
+            mount_guard.mount_id,
+            old_repo_mount_point_saved.as_deref().unwrap_or("<unknown>"),
+            mount_guard_old_repo.mount_id,
+        );
+        // Prevent the Drop impl from unmounting.
+        mount_guard.unmounted.store(true, Ordering::Release);
+        mount_guard_old_repo
+            .unmounted
+            .store(true, Ordering::Release);
+    } else {
+        mount_guard.unmount().await;
+        mount_guard_old_repo.unmount().await;
+    }
 
     build_result
 }

--- a/orion/src/main.rs
+++ b/orion/src/main.rs
@@ -6,18 +6,22 @@ pub mod repo;
 mod util;
 mod ws;
 
+use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
+    // Load environment variables from .env file before initializing logging so
+    // log filters can be configured via RUST_LOG in local dev and deployments.
+    dotenvy::dotenv().ok();
+
     // Initialize structured logging
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .with_target(true)
         .init();
-
-    // Load environment variables from .env file
-    dotenvy::dotenv().ok();
 
     // Configure WebSocket server address
     let server_addr =
@@ -33,6 +37,10 @@ async fn main() {
     tracing::info!("Starting orion worker...");
     tracing::info!("  Worker ID: {}", worker_id);
     tracing::info!("  Connecting to server at: {}", server_addr);
+
+    if let Err(err) = antares::warmup_dicfuse().await {
+        tracing::warn!("Antares startup warmup failed: {}", err);
+    }
 
     // Start WebSocket client with persistent connection
     ws::run_client(server_addr, worker_id).await;

--- a/orion/systemd/orion-runner.service
+++ b/orion/systemd/orion-runner.service
@@ -24,9 +24,9 @@ ExecStart=/home/orion/orion-runner/run.sh
 Restart=always
 RestartSec=2
 
-# Grant capabilities for FUSE mounting
+# Grant capabilities for FUSE mounting and read-search bypass
 AmbientCapabilities=CAP_SYS_ADMIN
-CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 
 # Basic hardening (relaxed for FUSE operations)
 NoNewPrivileges=false

--- a/orion/td_util/src/file_tail.rs
+++ b/orion/td_util/src/file_tail.rs
@@ -53,9 +53,14 @@ where
     let compressed_path = compressed_path.as_ref();
 
     // Wait for the event log file to appear (buck2 creates it after startup).
-    // Use a bounded wait; if the file never shows up (e.g. zero targets) we
-    // exit gracefully so the caller is not blocked.
-    let wait_timeout = Duration::from_secs(30);
+    // The buck2 daemon may take a long time to initialize on cold FUSE caches
+    // (up to BUCKD_STARTUP_INIT_TIMEOUT, typically 1200s), so we use a generous
+    // default here. Override via ORION_EVENT_LOG_WAIT_TIMEOUT_SECS if needed.
+    let wait_timeout_secs: u64 = std::env::var("ORION_EVENT_LOG_WAIT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300);
+    let wait_timeout = Duration::from_secs(wait_timeout_secs);
     let wait_start = tokio::time::Instant::now();
     loop {
         if compressed_path.exists() {
@@ -82,6 +87,9 @@ where
     drop(temp_file); // Close it for now, will open asynchronously later
 
     // Asynchronously open the compressed file and the temp file
+    // Note: there is a small TOCTOU window between the exists() check above
+    // and the File::open here (the file could be removed if buck2 is killed).
+    // This is acceptable because buck2 owns the file lifecycle during a build.
     let compressed_file = File::open(compressed_path).await?;
     let mut decoder = ZstdDecoder::new(BufReader::with_capacity(256 * 1024, compressed_file));
     let temp_file = File::create(&temp_path).await?;
@@ -119,6 +127,9 @@ where
             let mut offset = 0u64;
             let mut buffer = String::new();
             // Count consecutive empty reads so we can exit after decompression is done.
+            // After decompression finishes, we allow up to MAX_EMPTY_POLLS_AFTER_DONE
+            // consecutive empty reads (each separated by `poll_interval`) before exiting.
+            // With the default 200ms poll_interval this means ~1s of draining time.
             let mut empty_polls: u32 = 0;
             const MAX_EMPTY_POLLS_AFTER_DONE: u32 = 5;
 

--- a/orion/td_util/src/file_tail.rs
+++ b/orion/td_util/src/file_tail.rs
@@ -52,6 +52,30 @@ where
 {
     let compressed_path = compressed_path.as_ref();
 
+    // Wait for the event log file to appear (buck2 creates it after startup).
+    // Use a bounded wait; if the file never shows up (e.g. zero targets) we
+    // exit gracefully so the caller is not blocked.
+    let wait_timeout = Duration::from_secs(30);
+    let wait_start = tokio::time::Instant::now();
+    loop {
+        if compressed_path.exists() {
+            break;
+        }
+        if tx.is_closed() {
+            // Nobody is listening for events anymore.
+            return Ok(());
+        }
+        if wait_start.elapsed() >= wait_timeout {
+            tracing::warn!(
+                "Event log file did not appear within {}s, skipping tail: {}",
+                wait_timeout.as_secs(),
+                compressed_path.display()
+            );
+            return Ok(());
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
     // Create a temporary file
     let temp_file = NamedTempFile::new()?;
     let temp_path = temp_file.path().to_path_buf();
@@ -63,53 +87,77 @@ where
     let temp_file = File::create(&temp_path).await?;
     let mut temp_writer = BufWriter::with_capacity(256 * 1024, temp_file);
 
+    // Shared flag: set to true once decompression reaches EOF.
+    let decompress_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
     // Spawn a task to asynchronously decompress into the temp file
-    let decompress_task = tokio::spawn(async move {
-        let mut buffer = vec![0u8; 256 * 1024];
-        loop {
-            let bytes_read = decoder.read(&mut buffer).await?;
-            if bytes_read == 0 {
-                break; // EOF
+    let decompress_task = {
+        let done = decompress_done.clone();
+        tokio::spawn(async move {
+            let mut buffer = vec![0u8; 256 * 1024];
+            loop {
+                let bytes_read = decoder.read(&mut buffer).await?;
+                if bytes_read == 0 {
+                    break; // EOF
+                }
+                temp_writer.write_all(&buffer[..bytes_read]).await?;
+                temp_writer.flush().await?;
             }
-            temp_writer.write_all(&buffer[..bytes_read]).await?;
-            temp_writer.flush().await?;
-        }
-        Ok::<(), anyhow::Error>(())
-    });
+            done.store(true, std::sync::atomic::Ordering::Release);
+            Ok::<(), anyhow::Error>(())
+        })
+    };
 
     // Spawn a task to asynchronously tail the temp file
-    let tail_task = tokio::spawn(async move {
-        // Open the temporary file for reading
-        let file = File::open(&temp_path).await?;
-        let mut reader = BufReader::with_capacity(256 * 1024, file);
+    let tail_task = {
+        let done = decompress_done;
+        tokio::spawn(async move {
+            // Open the temporary file for reading
+            let file = File::open(&temp_path).await?;
+            let mut reader = BufReader::with_capacity(256 * 1024, file);
 
-        let mut offset = 0u64;
-        let mut buffer = String::new();
+            let mut offset = 0u64;
+            let mut buffer = String::new();
+            // Count consecutive empty reads so we can exit after decompression is done.
+            let mut empty_polls: u32 = 0;
+            const MAX_EMPTY_POLLS_AFTER_DONE: u32 = 5;
 
-        loop {
-            // Seek to the last read offset
-            reader.seek(io::SeekFrom::Start(offset)).await?;
-            buffer.clear();
-            let bytes_read = reader.read_line(&mut buffer).await?;
+            loop {
+                // Seek to the last read offset
+                reader.seek(io::SeekFrom::Start(offset)).await?;
+                buffer.clear();
+                let bytes_read = reader.read_line(&mut buffer).await?;
 
-            if bytes_read == 0 {
-                // No new data, wait for the next poll
-                tokio::time::sleep(poll_interval).await;
-                continue;
+                if bytes_read == 0 {
+                    // If decompression is finished and we've drained all data, exit.
+                    if done.load(std::sync::atomic::Ordering::Acquire) {
+                        empty_polls += 1;
+                        if empty_polls >= MAX_EMPTY_POLLS_AFTER_DONE {
+                            break;
+                        }
+                    }
+                    if tx.is_closed() {
+                        break;
+                    }
+                    // No new data, wait for the next poll
+                    tokio::time::sleep(poll_interval).await;
+                    continue;
+                }
+
+                empty_polls = 0;
+                offset += bytes_read as u64;
+                let line = buffer.trim_end_matches(&['\n', '\r'][..]).to_string();
+
+                // Send the line, break if receiver has been dropped
+                if tx.send(line).await.is_err() {
+                    break;
+                }
             }
+            Ok::<(), anyhow::Error>(())
+        })
+    };
 
-            offset += bytes_read as u64;
-            let line = buffer.trim_end_matches(&['\n', '\r'][..]).to_string();
-
-            // Send the line, break if receiver has been dropped
-            if tx.send(line).await.is_err() {
-                break;
-            }
-        }
-        Ok::<(), anyhow::Error>(())
-    });
-
-    // Wait for both tasks to complete (decompression may finish first; tail will keep polling)
+    // Wait for both tasks to complete
     let (_, tail_result) = tokio::join!(decompress_task, tail_task);
 
     // Return the result of the tail task


### PR DESCRIPTION

- Add Dicfuse warmup on Orion startup to eliminate cold-start latency
  for the first build request (antares.rs)
- Remove --isolation-dir from all buck2 invocations; each FUSE mount
  already produces a unique project root so Buck2 naturally isolates
  daemons without it. Drop ring/hex dependencies accordingly
- Switch tracing init to EnvFilter so RUST_LOG can suppress noisy
  dependency warnings (e.g. rfuse3 alignment messages)
- Move .env loading before logger init so RUST_LOG from .env takes effect
- Fix --event-log placement: it is a build subcommand flag, not a
  global option
- Fix event log tail hanging: wait up to 30s for the file to appear,
  signal tail loop to exit once decompression finishes, and abort
  tracker tasks on build completion to prevent leaks
- Bump scorpiofs 0.2.0 → 0.2.1
- Run as root in systemd unit to avoid capability issues with chmod
- Keep failed-build mounts alive for debugging instead of unmounting
- Suppress dead_code warnings for temporarily-disabled unmount infra