### PR TITLE
feat: Bot Installation

### DIFF
--- a/ceres/src/model/bots.rs
+++ b/ceres/src/model/bots.rs
@@ -1,0 +1,90 @@
+use callisto::{
+    bot_installations,
+    sea_orm_active_enums::{InstallationBotStatusEnum, InstallationTargetTypeEnum},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct BotRes {
+    pub id: i64,
+    pub bot_id: i64,
+    pub target_type: InstallationTargetType,
+    pub target_id: i64,
+    pub status: InstallationBotStatus,
+    pub installed_by: i64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct InstallBotReq {
+    pub target_type: InstallationTargetType,
+    pub target_id: i64,
+    pub installed_by: i64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct ChangeInstallationStatus {
+    pub target_type: InstallationTargetType,
+    pub status: InstallationBotStatus,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub enum InstallationBotStatus {
+    Disabled,
+    Enabled,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub enum InstallationTargetType {
+    Organization,
+    Repository,
+}
+
+impl From<bot_installations::Model> for BotRes {
+    fn from(value: bot_installations::Model) -> Self {
+        Self {
+            id: value.id,
+            bot_id: value.bot_id,
+            target_type: value.target_type.into(),
+            target_id: value.target_id,
+            status: value.status.into(),
+            installed_by: value.installed_by,
+        }
+    }
+}
+
+impl From<InstallationBotStatusEnum> for InstallationBotStatus {
+    fn from(value: InstallationBotStatusEnum) -> Self {
+        match value {
+            InstallationBotStatusEnum::Disabled => InstallationBotStatus::Disabled,
+            InstallationBotStatusEnum::Enabled => InstallationBotStatus::Enabled,
+        }
+    }
+}
+
+impl From<InstallationTargetTypeEnum> for InstallationTargetType {
+    fn from(value: InstallationTargetTypeEnum) -> Self {
+        match value {
+            InstallationTargetTypeEnum::Organization => InstallationTargetType::Organization,
+            InstallationTargetTypeEnum::Repository => InstallationTargetType::Repository,
+        }
+    }
+}
+
+impl From<InstallationBotStatus> for InstallationBotStatusEnum {
+    fn from(value: InstallationBotStatus) -> Self {
+        match value {
+            InstallationBotStatus::Disabled => InstallationBotStatusEnum::Disabled,
+            InstallationBotStatus::Enabled => InstallationBotStatusEnum::Enabled,
+        }
+    }
+}
+
+impl From<InstallationTargetType> for InstallationTargetTypeEnum {
+    fn from(value: InstallationTargetType) -> Self {
+        match value {
+            InstallationTargetType::Organization => InstallationTargetTypeEnum::Organization,
+            InstallationTargetType::Repository => InstallationTargetTypeEnum::Repository,
+        }
+    }
+}

--- a/ceres/src/model/mod.rs
+++ b/ceres/src/model/mod.rs
@@ -1,4 +1,5 @@
 pub mod blame;
+pub mod bots;
 pub mod buck;
 pub mod change_list;
 pub mod cl;

--- a/jupiter/callisto/src/entity_ext/bot_installations.rs
+++ b/jupiter/callisto/src/entity_ext/bot_installations.rs
@@ -1,0 +1,29 @@
+use chrono::Utc;
+
+use crate::{
+    bot_installations,
+    entity_ext::generate_id,
+    sea_orm_active_enums::{InstallationBotStatusEnum, InstallationTargetTypeEnum},
+};
+
+impl bot_installations::Model {
+    pub fn new(
+        bot_id: i64,
+        target_type: InstallationTargetTypeEnum,
+        target_id: i64,
+        status: InstallationBotStatusEnum,
+        installed_by: i64,
+    ) -> Self {
+        let now = Utc::now().into();
+
+        Self {
+            id: generate_id(),
+            bot_id,
+            target_type,
+            target_id,
+            status,
+            installed_by,
+            installed_at: now,
+        }
+    }
+}

--- a/jupiter/callisto/src/entity_ext/mod.rs
+++ b/jupiter/callisto/src/entity_ext/mod.rs
@@ -1,3 +1,4 @@
+pub mod bot_installations;
 pub mod bot_keys;
 pub mod bots;
 pub mod buck_session;

--- a/jupiter/src/storage/bots_storage.rs
+++ b/jupiter/src/storage/bots_storage.rs
@@ -1,8 +1,10 @@
 use std::ops::Deref;
 
 use callisto::{
-    bot_keys, bots,
-    sea_orm_active_enums::{BotStatusEnum, PermissionScopeEnum},
+    bot_installations, bot_keys, bots,
+    sea_orm_active_enums::{
+        BotStatusEnum, InstallationBotStatusEnum, InstallationTargetTypeEnum, PermissionScopeEnum,
+    },
 };
 use common::errors::MegaError;
 use rsa::{
@@ -10,7 +12,9 @@ use rsa::{
     pkcs8::{EncodePrivateKey, EncodePublicKey},
     rand_core::OsRng,
 };
-use sea_orm::{ActiveModelTrait, IntoActiveModel};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 
 use crate::storage::base_storage::{BaseStorage, StorageConnector};
 
@@ -71,6 +75,101 @@ impl BotsStorage {
 
         // 6. Return the bot record and private key (returned only once)
         Ok((bot, private_pem))
+    }
+
+    pub async fn get_installed_bot_by_id(
+        &self,
+        bot_id: i64,
+    ) -> Result<Vec<bot_installations::Model>, MegaError> {
+        let installations = bot_installations::Entity::find()
+            .filter(bot_installations::Column::BotId.eq(bot_id))
+            .all(self.get_connection())
+            .await?;
+
+        Ok(installations)
+    }
+
+    /// Install a bot to a target (organization or repository)
+    pub async fn install_bot(
+        &self,
+        bot_id: i64,
+        target_type: InstallationTargetTypeEnum,
+        target_id: i64,
+        installed_by: i64,
+    ) -> Result<bot_installations::Model, MegaError> {
+        // Check if already installed
+        if (bot_installations::Entity::find()
+            .filter(bot_installations::Column::BotId.eq(bot_id))
+            .filter(bot_installations::Column::TargetType.eq(target_type.clone()))
+            .filter(bot_installations::Column::TargetId.eq(target_id))
+            .one(self.get_connection())
+            .await?)
+            .is_some()
+        {
+            return Err(MegaError::Other(
+                "Bot already installed on this target".into(),
+            ));
+        }
+
+        // Insert installation record
+        let model = bot_installations::Model::new(
+            bot_id,
+            target_type,
+            target_id,
+            InstallationBotStatusEnum::Enabled,
+            installed_by,
+        );
+
+        let active_model = model.into_active_model();
+
+        let res = active_model.insert(self.get_connection()).await?;
+        Ok(res)
+    }
+
+    /// Uninstall a bot from a target
+    pub async fn uninstall_bot(
+        &self,
+        bot_id: i64,
+        target_type: InstallationTargetTypeEnum,
+        target_id: i64,
+    ) -> Result<(), MegaError> {
+        let installation = bot_installations::Entity::find()
+            .filter(bot_installations::Column::BotId.eq(bot_id))
+            .filter(bot_installations::Column::TargetType.eq(target_type.clone()))
+            .filter(bot_installations::Column::TargetId.eq(target_id))
+            .one(self.get_connection())
+            .await?
+            .ok_or_else(|| MegaError::Other("Bot installation not found".into()))?
+            .into_active_model();
+
+        installation
+            .into_active_model()
+            .delete(self.get_connection())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Change the status of an installed bot (Enabled / Disabled)
+    pub async fn change_installed_bot_status(
+        &self,
+        bot_id: i64,
+        target_type: InstallationTargetTypeEnum,
+        target_id: i64,
+        status: InstallationBotStatusEnum,
+    ) -> Result<bot_installations::Model, MegaError> {
+        let mut installation = bot_installations::Entity::find()
+            .filter(bot_installations::Column::BotId.eq(bot_id))
+            .filter(bot_installations::Column::TargetType.eq(target_type.clone()))
+            .filter(bot_installations::Column::TargetId.eq(target_id))
+            .one(self.get_connection())
+            .await?
+            .ok_or_else(|| MegaError::Other("Bot installation not found".into()))?
+            .into_active_model();
+
+        installation.status = Set(status);
+        let res = installation.update(self.get_connection()).await?;
+        Ok(res)
     }
 
     pub async fn new_bot_model(

--- a/jupiter/src/storage/mod.rs
+++ b/jupiter/src/storage/mod.rs
@@ -432,6 +432,10 @@ impl Storage {
         self.app_service.webhook_storage.clone()
     }
 
+    pub fn bots_storage(&self) -> BotsStorage {
+        self.app_service.bots_storage.clone()
+    }
+
     pub fn mock() -> Self {
         // During test time, we don't need a AppContext,
         // Put config in a leaked static variable thus the weak reference will always be valid.

--- a/mono/src/api/api_router.rs
+++ b/mono/src/api/api_router.rs
@@ -16,10 +16,10 @@ use crate::{
         error::ApiError,
         notes::note_router,
         router::{
-            admin_router, buck_router, build_trigger_router, cl_router, code_review_router,
-            commit_router, conv_router, dynamic_sidebar_router, gpg_router, group_router,
-            issue_router, label_router, merge_queue_router, permission_router, preview_router,
-            repo_router, reviewer_router, tag_router, user_router, webhook_router,
+            admin_router, bot_router, buck_router, build_trigger_router, cl_router,
+            code_review_router, commit_router, conv_router, dynamic_sidebar_router, gpg_router,
+            group_router, issue_router, label_router, merge_queue_router, permission_router,
+            preview_router, repo_router, reviewer_router, tag_router, user_router, webhook_router,
         },
     },
     server::http_server::SYSTEM_COMMON,
@@ -51,6 +51,7 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
         .merge(code_review_router::routers())
         .merge(build_trigger_router::routers())
         .merge(webhook_router::routers())
+        .merge(bot_router::routers())
 }
 
 /// Health Check

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -59,7 +59,7 @@ async fn install_bot(
     params(
         ("id", description = "Bots ID"),
     ),
-    path = "/{id}/installations ",
+    path = "/{id}/installations",
     responses(
         (status = 200, body = CommonResult<Vec<BotRes>>, content_type = "application/json")
     ),

--- a/mono/src/api/router/bot_router.rs
+++ b/mono/src/api/router/bot_router.rs
@@ -1,0 +1,141 @@
+use api_model::common::CommonResult;
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use ceres::model::bots::{BotRes, ChangeInstallationStatus, InstallBotReq, InstallationTargetType};
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::{
+    api::{MonoApiServiceState, error::ApiError},
+    server::http_server::BOTS_TAG,
+};
+
+pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
+    OpenApiRouter::new().nest(
+        "/bots",
+        OpenApiRouter::new()
+            .routes(routes!(install_bot))
+            .routes(routes!(list_installed_bot))
+            .routes(routes!(change_installation_status))
+            .routes(routes!(uninstall_bot)),
+    )
+}
+
+/// Install bot
+#[utoipa::path(
+    post,
+    params(
+        ("id", description = "Bots ID"),
+    ),
+    path = "/{id}/installations ",
+    responses(
+        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
+    ),
+    tag = BOTS_TAG
+)]
+async fn install_bot(
+    state: State<MonoApiServiceState>,
+    Path(id): Path<i64>,
+    Json(json): Json<InstallBotReq>,
+) -> Result<Json<CommonResult<BotRes>>, ApiError> {
+    let bot = state
+        .storage
+        .bots_storage()
+        .install_bot(
+            id,
+            json.target_type.into(),
+            json.target_id,
+            json.installed_by,
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(bot.into()))))
+}
+
+/// Get installed bot
+#[utoipa::path(
+    get,
+    params(
+        ("id", description = "Bots ID"),
+    ),
+    path = "/{id}/installations ",
+    responses(
+        (status = 200, body = CommonResult<Vec<BotRes>>, content_type = "application/json")
+    ),
+    tag = BOTS_TAG
+)]
+async fn list_installed_bot(
+    state: State<MonoApiServiceState>,
+    Path(id): Path<i64>,
+) -> Result<Json<CommonResult<Vec<BotRes>>>, ApiError> {
+    let models = state
+        .storage
+        .bots_storage()
+        .get_installed_bot_by_id(id)
+        .await?
+        .into_iter()
+        .map(|m| m.into())
+        .collect();
+
+    Ok(Json(CommonResult::success(Some(models))))
+}
+
+#[utoipa::path(
+    patch,
+    params(
+        ("id", description = "Bot ID"),
+        ("installation_id", description = "Installation ID"),
+    ),
+    path = "/{id}/installations/{installation_id}",
+    responses(
+        (status = 200, body = CommonResult<BotRes>, content_type = "application/json")
+    ),
+    tag = BOTS_TAG
+)]
+async fn change_installation_status(
+    state: State<MonoApiServiceState>,
+    Path((id, installation_id)): Path<(i64, i64)>,
+    Json(json): Json<ChangeInstallationStatus>,
+) -> Result<Json<CommonResult<BotRes>>, ApiError> {
+    let model = state
+        .storage
+        .bots_storage()
+        .change_installed_bot_status(
+            id,
+            json.target_type.into(),
+            installation_id,
+            json.status.into(),
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(model.into()))))
+}
+
+#[utoipa::path(
+    delete,
+    params(
+        ("id", description = "Bot ID"),
+        ("installation_id", description = "Installation ID"),
+    ),
+    path = "/{id}/installations/{installation_id}",
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = BOTS_TAG
+)]
+async fn uninstall_bot(
+    state: State<MonoApiServiceState>,
+    Path((id, installation_id)): Path<(i64, i64)>,
+    Json(target_type): Json<InstallationTargetType>,
+) -> Result<Json<CommonResult<String>>, ApiError> {
+    state
+        .storage
+        .bots_storage()
+        .uninstall_bot(id, target_type.into(), installation_id)
+        .await?;
+
+    Ok(Json(CommonResult::success(Some(
+        "Bot uninstalled successfully".to_string(),
+    ))))
+}

--- a/mono/src/api/router/mod.rs
+++ b/mono/src/api/router/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_router;
+pub mod bot_router;
 pub mod buck_router;
 pub mod build_trigger_router;
 pub mod cl_router;

--- a/mono/src/server/http_server.rs
+++ b/mono/src/server/http_server.rs
@@ -429,6 +429,7 @@ pub const CODE_REVIEW_TAG: &str = "Code Review";
 pub const BUILD_TRIGGER_TAG: &str = "Build Trigger";
 pub const GROUP_PERMISSION_TAG: &str = "Group Permission Management";
 pub const WEBHOOK_TAG: &str = "Webhook";
+pub const BOTS_TAG: &str = "Bots";
 #[derive(OpenApi)]
 #[openapi()]
 struct ApiDoc;


### PR DESCRIPTION
实现 Bot Installation 管理接口

**描述**
新增 Bot 安装管理相关逻辑。（ issue： https://github.com/web3infra-foundation/mega/issues/1998 ）

* Storage 层新增 `install_bot`、`uninstall_bot`、`change_installed_bot_status`、`get_installed_bot_by_id` 方法
* 新增 API：

  * `POST /bots/{id}/installations` 安装 Bot
  * `GET /bots/{id}/installations` 查询安装列表
  * `PATCH /bots/{id}/installations/{installation_id}` 修改安装状态
  * `DELETE /bots/{id}/installations/{installation_id}` 卸载 Bot

用于管理 Bot 在 Organization / Repository 等目标上的安装关系。
