### PR TITLE
feat: optimize Files Changed view to display renamed file

### DIFF
--- a/moon/apps/web/components/DiffView/FileDiff.tsx
+++ b/moon/apps/web/components/DiffView/FileDiff.tsx
@@ -226,6 +226,7 @@ export default function FileDiff({
   const DiffItemComponent = (index: number) => {
     const { file, fileDiffMetadata, stats, changeType, isBinary, hasContent } = parsedFiles[index]
     const isExpanded = expandedMap[file.path]
+    const isRenamed = changeType === 'rename-pure' || changeType === 'rename-changed'
 
     return (
       <div
@@ -247,7 +248,17 @@ export default function FileDiff({
             ) : (
               <ExpandIcon className='align-middle text-xl' />
             )}
-            <span className='ml-1'>{file.path}</span>
+            <span className='ml-1'>
+              {isRenamed && file.oldPath ? (
+                <span>
+                  <span className='text-secondary line-through'>{file.oldPath}</span>
+                  <span className='text-secondary mx-1'>→</span>
+                  <span>{file.path}</span>
+                </span>
+              ) : (
+                file.path
+              )}
+            </span>
           </span>
           <span className='text-xs font-bold'>
             <span className='text-green-500'>+{stats.additions}</span>{' '}

--- a/moon/apps/web/components/DiffView/parsedDiffs.ts
+++ b/moon/apps/web/components/DiffView/parsedDiffs.ts
@@ -5,10 +5,11 @@ import { getLanguageForFile } from '@/utils/shikiLanguageFallback'
 export interface DiffItem {
   data: string
   path: string
+  old_path?: string // Only present for renamed files
 }
 
 export interface ParsedFile {
-  file: { path: string; lang: string; diff: string }
+  file: { path: string; lang: string; diff: string; oldPath?: string }
   fileDiffMetadata: FileDiffMetadata | null
   stats: { additions: number; deletions: number }
   changeType: ChangeTypes | null
@@ -16,7 +17,7 @@ export interface ParsedFile {
   hasContent: boolean
 }
 
-export function parsedDiffs(diffText: DiffItem[]): { path: string; lang: string; diff: string }[] {
+export function parsedDiffs(diffText: DiffItem[]): { path: string; lang: string; diff: string; oldPath?: string }[] {
   if (diffText.length < 1) return []
 
   return diffText.map((block) => {
@@ -26,12 +27,15 @@ export function parsedDiffs(diffText: DiffItem[]): { path: string; lang: string;
     return {
       path: block.path,
       lang: isBinary ? 'binary' : 'auto',
-      diff
+      diff,
+      oldPath: block.old_path
     }
   })
 }
 
-export function generateParsedFiles(diffFiles: { path: string; lang: string; diff: string }[]): ParsedFile[] {
+export function generateParsedFiles(
+  diffFiles: { path: string; lang: string; diff: string; oldPath?: string }[]
+): ParsedFile[] {
   return diffFiles.map((file) => {
     let fileDiffMetadata: FileDiffMetadata | null = null
     let additions = 0


### PR DESCRIPTION
<img width="1409" height="293" alt="image" src="https://github.com/user-attachments/assets/7c354d64-7833-464b-9a30-403f8d20e460" />

改变原有“先删除再添加”的展示逻辑，直接渲染为“旧路径 → 新路径”。