### PR TITLE
feat(cla): limit CLA sign button display to CL authors only

### DIFF
--- a/moon/apps/web/components/ClBox/MergeBox.tsx
+++ b/moon/apps/web/components/ClBox/MergeBox.tsx
@@ -19,7 +19,7 @@ import { useMergeChecks } from './hooks/useMergeChecks'
 import { MergeSection } from './MergeSection'
 import { ReviewerSection } from './ReviewerSection'
 
-export const MergeBox = React.memo<{ prId: string; status?: string }>(({ prId, status }) => {
+export const MergeBox = React.memo<{ prId: string; status?: string; author?: string }>(({ prId, status, author }) => {
   const { checks } = useMergeChecks(prId)
   const [hasCheckFailures, setHasCheckFailures] = useState(true)
   const route = useRouter()
@@ -67,6 +67,8 @@ export const MergeBox = React.memo<{ prId: string; status?: string }>(({ prId, s
   const claCondition = additionalChecks.find((c) => c.type === CheckType.ClaSign)
   const claCheck = claCondition ? claCondition.result === ConditionResult.PASSED : true
 
+  const isClAuthor = data?.username === author
+
   return (
     <div className='flex'>
       <FeedMergedIcon size={24} className='text-tertiary ml-1' />
@@ -93,6 +95,7 @@ export const MergeBox = React.memo<{ prId: string; status?: string }>(({ prId, s
             clStatus={status}
             clLink={id}
             claCheck={claCheck}
+            isClAuthor={isClAuthor}
           />
         </div>
       )}

--- a/moon/apps/web/components/ClBox/MergeSection.tsx
+++ b/moon/apps/web/components/ClBox/MergeSection.tsx
@@ -18,6 +18,7 @@ interface MergeSectionProps {
   clLink: string
   clStatus?: string
   claCheck?: boolean
+  isClAuthor?: boolean
 }
 
 const STATUS_POLL_INTERVAL_MS = 3000
@@ -30,7 +31,8 @@ export const MergeSection = React.memo<MergeSectionProps>(
     onApprove,
     clLink,
     clStatus,
-    claCheck = true
+    claCheck = true,
+    isClAuthor = false
   }) => {
     const router = useRouter()
     const { scope } = useScope()
@@ -149,7 +151,7 @@ export const MergeSection = React.memo<MergeSectionProps>(
               </button>
             )}
 
-            {claCheck === false && (
+            {claCheck === false && isClAuthor && (
               <button
                 onClick={() => router.push(`/me/settings/cla/sign`)}
                 className='w-full rounded-md bg-blue-600 px-4 py-2 font-bold text-white duration-500 hover:bg-blue-800'

--- a/moon/apps/web/components/ClView/ConversationTab.tsx
+++ b/moon/apps/web/components/ClView/ConversationTab.tsx
@@ -118,7 +118,7 @@ export const ConversationTab = React.memo<ConversationTabProps>(
         <div style={{ marginTop: '12px' }} className='prose'>
           <div className='w-full'>
             {clDetail && (clDetail.status === 'Open' || clDetail.status === 'Draft') && (
-              <MergeBox prId={id} status={clDetail.status} />
+              <MergeBox prId={id} status={clDetail.status} author={clDetail.author} />
             )}
           </div>
           <h2 style={{ marginTop: '15px', marginBottom: '15px' }}>Add a comment</h2>


### PR DESCRIPTION
- 在 MergeBox 组件中添加 author 参数，用于接收 CL 作者信息
- 新增 isClAuthor 判断逻辑，比对当前用户与 CL 作者
- 在 MergeSection 组件中添加 isClAuthor 属性，控制 CLA 签署按钮显示权限
- 修改 ConversationTab 组件，从 clDetail 中提取 author 并传递给 MergeBox
- CLA 签署按钮现在仅在 CLA 检查未通过且当前用户为 CL 作者时显示